### PR TITLE
Changed default constructor values of API client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocsf-lib"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tools for working with the OCSF schema"
 authors = ["Jeremy Fisher <jeremy@query.ai>"]
 readme = "README.md"

--- a/src/ocsf/api/client.py
+++ b/src/ocsf/api/client.py
@@ -92,7 +92,7 @@ class OcsfApiClient:
 
     def __init__(
         self,
-        base_url: str = "https://schema.ocsf.io",
+        base_url: Optional[str] = None,
         cache_dir: Optional[str | Path] = None,
         schema_options: SchemaOptions = SchemaOptions(),
         fetch_profiles: bool = True,
@@ -107,7 +107,7 @@ class OcsfApiClient:
             fetch_profiles: If True, fetch available profiles when fetching a schema.
             fetch_extensions: If True, fetch available extensions when fetching a schema.
         """
-        self._base_url = base_url
+        self._base_url = base_url or "https://schema.ocsf.io"
         self._versions: Optional[SchemaVersions] = None
         self._fetch_profiles = fetch_profiles
         self._fetch_extensions = fetch_extensions


### PR DESCRIPTION
This changes the default value of the `base_url` parameter in the API client to make it a little friendlier to override the base URL.

The need (want?) for this arose when adding the downstream `ocsf-validate-compatibility` to the `ocsf-schema` PR workflow.