### PR TITLE
Compile debugging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocsf-lib"
-version = "0.6.0"
+version = "0.7.0"
 description = "Tools for working with the OCSF schema"
 authors = ["Jeremy Fisher <jeremy@query.ai>"]
 readme = "README.md"

--- a/src/ocsf/compile/README.md
+++ b/src/ocsf/compile/README.md
@@ -1,5 +1,7 @@
 # OCSF Compiler
 
+## About
+
 The `ocsf.compiler` package provides an alternative to "compiling" OCSF schemata
 with the OCSF server. It is meant to be transparent and approachable. We have
 preferred to make operations explicit and readable over efficiency.
@@ -36,3 +38,35 @@ definitions into an OCSF schema representation using the `ocsf.schema` package.
 
 Crucially, _no_ operations are completed during planning. This means planners
 err on the side of identifying operations that may later be noops.
+
+## Usage
+
+You can compile a schema from a repository and dump it as JSON to STDOUT with the following:
+
+```sh
+$ python -m ocsf.compile path/to/schema
+```
+
+You can also view the (many) operations performed to build the schema with the `debug` module:
+
+```sh
+$ python -m ocsf.compile.debug path/to/schema
+```
+
+The debug utility can also be used to list the properties changed by each operation and to narrow the list of operations down to just a specific file or a file and all of its prerequisite files. For more information, see its help:
+
+```
+usage: debug.py [-h] [--file FILE] [--prereqs] [--changes] [--no-changes] path
+
+Debugging tool for OCSF compilation
+
+positional arguments:
+  path          Path to the OCSF repository
+
+options:
+  -h, --help    show this help message and exit
+  --file FILE   Narrow output to operations involving <file>.
+  --prereqs     Include operations on prerequisites of <file>.
+  --changes     Show changed properties as well as operations.
+  --no-changes  Show only operations.
+```

--- a/src/ocsf/compile/compiler.py
+++ b/src/ocsf/compile/compiler.py
@@ -40,7 +40,7 @@ CompilationPlan = list[Operation]
 
 FileMutations = list[tuple[Operation, MergeResult]]
 CompilationMutations = dict[RepoPath, FileMutations]
-
+PlanningPhase = list[Planner]
 
 class Compilation:
     def __init__(self, repo: Repository, options: CompilationOptions = CompilationOptions()):
@@ -53,25 +53,75 @@ class Compilation:
 
         # The arrangement of planners to phases is very important. If you think
         # it needs to change, you're probably wrong.
-        self._planners: list[list[Planner]] = [
+        self._planners: list[PlanningPhase] = [
             [
+                # Expand annotations in profiles and includes.
                 AnnotationPlanner(self._proto, options),
+
+                # Set the extension property of objects and events introduced to
+                # core by extensions.
                 MarkExtensionPlanner(self._proto, options),
+                
+                # Set the profile name of attributes to the profile that adds
+                # them to the object or event.
                 MarkProfilePlanner(self._proto, options),
+                
+                # Process $include directives.
                 IncludePlanner(self._proto, options),
+                
+                # Process extends directives.
                 ExtendsPlanner(self._proto, options),
+                
+                # Build the observable type_id enum based on values found across
+                # the schema.
                 BuildObservableTypesPlanner(self._proto, options),
+                
+                # Process definitions in extensions that modify records in core
+                # (reverse extends?).
                 ExtensionMergePlanner(self._proto, options),
+                
+                # Remove attributes from deactivated profiles.
                 ExcludeProfileAttrsPlanner(self._proto, options),
             ],
-            [SetCategoryPlanner(self._proto, options)],
-            [UidPlanner(self._proto, options), DictionaryPlanner(self._proto, options)],
             [
+                # Set the category of events.
+                # TODO: Can this be performed in the prior phase?
+                SetCategoryPlanner(self._proto, options),
+            ],
+            [
+                # Build the UID enumerations (type_id, class_uid, etc.).
+                UidPlanner(self._proto, options),
+                
+                # Complete missing attribute details using dictionary.json.
+                DictionaryPlanner(self._proto, options)
+            ],
+            [
+                # Prefix the names of objects and events added by extensions
+                # with their extension name, and also update all attribute type
+                # references to them. Only performed if
+                # options.prefix_extensions is True.
                 ExtensionPrefixPlanner(self._proto, options),
+                
+                # For attributes with object types, change type to object and
+                # populate the object_type and object_name properties to match
+                # the output of the OCSF server. Only performed if
+                # options.set_object_types is True.
                 ObjectTypePlanner(self._proto, options),
+                
+                # Build the sibling _name fields for UID enumerations.
                 UidSiblingPlanner(self._proto, options),
+                
+                # Apply the datetime synthetic profile.
                 DateTimePlanner(self._proto, options),
+                
+                # Set the observable property of attributes to the corresponding
+                # observable.type_id value to make building the observables
+                # attribute of records easier. Only performed if
+                # options.set_observable is True.
                 MarkObservablesPlanner(self._proto, options),
+                
+                # Copy records that are ONLY defined in extensions to the core
+                # schema so that they are included by ProtoSchema.schema().
                 ExtensionCopyPlanner(self._proto, options),
             ],
         ]

--- a/src/ocsf/compile/debug.py
+++ b/src/ocsf/compile/debug.py
@@ -1,0 +1,84 @@
+
+
+from argparse import ArgumentParser
+from pprint import pprint
+
+from ocsf.repository import read_repo
+
+from .compiler import Compilation
+from .planners.planner import Operation
+from .merge import MergeResult
+
+def find_prereqs(compilation: Compilation, file: str, found: set[str] | None = None) -> set[str]:
+    if found is None:
+        found = set()
+    for phase in compilation.analyze():
+        if file in phase:
+            for op in phase[file]:
+                if op.prerequisite is not None and op.prerequisite not in found:
+                    found.add(op.prerequisite)
+                    found |= find_prereqs(compilation, op.prerequisite, found)
+    return found
+
+def operations(compilation: Compilation, file: str | None = None, prereqs: bool = True):
+    if prereqs and file is not None:
+        files = find_prereqs(compilation, file)
+        files.add(file)
+    elif file is not None:
+        files = set()
+        files.add(file)
+    else:
+        files: set[str] = set()
+
+    order = compilation.order()
+    for op in order:
+        if file is None or op.target in files:
+            print(str(op))
+
+def mutations(compilation: Compilation, file: str | None = None, prereqs: bool = True):
+    if prereqs and file is not None:
+        files = find_prereqs(compilation, file)
+        files.add(file)
+    elif file is not None:
+        files = set()
+        files.add(file)
+    else:
+        files: set[str] = set()
+
+    compiled = compilation.compile()
+    mutations: dict[Operation, MergeResult] = {}
+    for f in files:
+        if file is None or f in files:
+            if f in compiled:
+                for mutation in compiled[f]:
+                    if len(mutation[1]) > 0:
+                        mutations[mutation[0]] = mutation[1]
+
+    ordered = compilation.order()
+    for op in ordered:
+        if op in mutations:
+            print(str(op))
+            pprint(mutations[op])
+            print()
+
+def main():
+    parser = ArgumentParser(description="Debugging tool for OCSF compilation")
+    parser.add_argument("path", help="Path to the OCSF repository")
+    parser.add_argument("--file", default=None, help="Narrow output to operations involving <file>.")
+    parser.add_argument("--prereqs", action="store_true", default=False, help="Include operations on prerequisites of <file>.")
+    parser.add_argument("--changes", action="store_true", default=True, help="Show changed properties as well as operations.")
+    parser.add_argument("--no-changes", action="store_false", dest="changes", help="Show only operations.")
+
+    args = parser.parse_args()
+
+    compilation = Compilation(read_repo(args.path))
+    file = args.file
+    prereqs = args.prereqs
+
+    if args.changes:
+        mutations(compilation, file, prereqs)
+    else:
+        operations(compilation, file, prereqs)
+
+if __name__ == "__main__":
+    main()

--- a/src/ocsf/compile/planners/datetime.py
+++ b/src/ocsf/compile/planners/datetime.py
@@ -11,6 +11,9 @@ from .planner import Operation, Planner, Analysis
 class DateTimeOp(Operation):
     """Append the category and class names to the description of the category_name and class_name attributes."""
 
+    def __str__(self):
+        return f"Building datetime attributes in {self.target}"
+
     def apply(self, schema: ProtoSchema) -> MergeResult:
         data = schema[self.target].data
         assert isinstance(data, DefnWithAttrs)

--- a/src/ocsf/compile/planners/dictionary.py
+++ b/src/ocsf/compile/planners/dictionary.py
@@ -10,7 +10,7 @@ from ocsf.repository import DefinitionFile, AnyDefinition, SpecialFiles, Diction
 @dataclass(eq=True, frozen=True)
 class DictionaryOp(Operation):
     def __str__(self):
-        return f"Dictionary {self.target} <- {self.prerequisite}"
+        return f"Complete attributes from dictionary {self.target} <- {self.prerequisite}"
 
     def apply(self, schema: ProtoSchema) -> MergeResult:
         target = schema[self.target]

--- a/src/ocsf/compile/planners/extension.py
+++ b/src/ocsf/compile/planners/extension.py
@@ -127,7 +127,7 @@ class MarkExtensionOp(Operation):
         return [("src_extension",)]
 
     def __str__(self):
-        return f"Extension creates {self.target} <- {self.prerequisite}"
+        return f"Mark extension {self.target} <- {self.prerequisite}"
 
 
 class MarkExtensionPlanner(ExtensionPlanner):
@@ -168,7 +168,7 @@ class PrefixKeyOp(Operation):
         return []
 
     def __str__(self):
-        return f"Prepend extension name to {self.target}"
+        return f"Prepend extension in name of {self.target}"
 
 
 class _ExtensionTypeMap:
@@ -231,6 +231,9 @@ class PrefixTypeOp(Operation):
     """This operation prefixes the type references of attributes with an extension name where appropriate."""
 
     map: Optional[_ExtensionTypeMap] = None
+
+    def __str__(self):
+        return f"Prefix types with extensions in {self.target}"
 
     def apply(self, schema: ProtoSchema) -> MergeResult:
         source = schema[self.target]

--- a/src/ocsf/compile/planners/object_type.py
+++ b/src/ocsf/compile/planners/object_type.py
@@ -44,7 +44,7 @@ class ObjectTypeOp(Operation):
     types: Optional[_Types] = None
 
     def __str__(self):
-        return f"SetObjectType {self.target}"
+        return f"Set object type in {self.target}"
 
     def apply(self, schema: ProtoSchema) -> MergeResult:
         assert self.types is not None

--- a/src/ocsf/compile/planners/observable.py
+++ b/src/ocsf/compile/planners/observable.py
@@ -99,7 +99,7 @@ class MarkObservablesOp(Operation):
     registry: Optional[_Registry] = None
 
     def __str__(self):
-        return f"Set observables in {self.target}"
+        return f"Mark observable property of attributes in {self.target}"
 
     def apply(self, schema: ProtoSchema) -> MergeResult:
         assert self.registry is not None

--- a/src/ocsf/compile/planners/profile.py
+++ b/src/ocsf/compile/planners/profile.py
@@ -52,7 +52,7 @@ class ExcludeProfileAttrsOp(Operation):
         return result
 
     def __str__(self):
-        return f"Exclude Profile {self.target} <- {self.prerequisite}"
+        return f"Exclude profile {self.target} <- {self.prerequisite}"
 
 
 @dataclass(eq=True, frozen=True)
@@ -80,7 +80,7 @@ class MarkProfileOp(Operation):
         return result
 
     def __str__(self):
-        return f"Mark Profile {self.target} <- {self.prerequisite}"
+        return f"Mark profile {self.target} <- {self.prerequisite}"
 
 
 def _find_profile(schema: ProtoSchema, profile_ref: str, relative_to: str) -> str | None:

--- a/src/ocsf/compile/planners/uid.py
+++ b/src/ocsf/compile/planners/uid.py
@@ -138,7 +138,7 @@ class UidOp(Operation):
         )
 
     def __str__(self):
-        return f"UIDs for {self.target}"
+        return f"Building UID enums for {self.target}"
 
 
 class UidPlanner(Planner):

--- a/src/ocsf/compile/planners/uid_names.py
+++ b/src/ocsf/compile/planners/uid_names.py
@@ -12,6 +12,9 @@ from .planner import Operation, Planner, Analysis
 class UidSiblingOp(Operation):
     """Append the category and class names to the description of the category_name and class_name attributes."""
 
+    def __str__(self):
+        return f"Building UID name sibling attributes in {self.target}"
+
     def apply(self, schema: ProtoSchema) -> MergeResult:
         data = schema[self.target].data
         assert isinstance(data, EventDefn)


### PR DESCRIPTION
This PR adds a simple debugging utility for schema compilation that displays operations performed in the compilation process and, optionally, the properties of each file the operation changed.

Access it with `python -m ocsf.compile.debug`.

```
usage: debug.py [-h] [--file FILE] [--prereqs] [--changes] [--no-changes] path

Debugging tool for OCSF compilation

positional arguments:
  path          Path to the OCSF repository

options:
  -h, --help    show this help message and exit
  --file FILE   Narrow output to operations involving <file>.
  --prereqs     Include operations on prerequisites of <file>.
  --changes     Show changed properties as well as operations.
  --no-changes  Show only operations.
```