### PR TITLE
Fixing cache for compatibility validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocsf-lib"
-version = "0.8.0"
+version = "0.8.1"
 description = "Tools for working with the OCSF schema"
 authors = ["Jeremy Fisher <jeremy@query.ai>"]
 readme = "README.md"

--- a/src/ocsf/compile/planners/extension.py
+++ b/src/ocsf/compile/planners/extension.py
@@ -32,6 +32,21 @@ class ExtensionPlanner(Planner):
         super().__init__(schema, options)
 
 
+# TODO Make the merge/"patch extends" case more explicit
+#
+# Extensions may modify the core:
+#  - Dictionary
+#  - Objects
+#  - Events
+#
+# In the case of objects and events, records must _not_ have a `name` property
+# AND must have an `extends` property.
+#
+# While we're at it, events in extensions don't have to be organized in a
+# directory structure that matches the core.
+#
+
+
 @dataclass(eq=True, frozen=True)
 class ExtensionModifyOp(Operation):
     def apply(self, schema: ProtoSchema) -> MergeResult:

--- a/src/ocsf/validate/compatibility/__main__.py
+++ b/src/ocsf/validate/compatibility/__main__.py
@@ -80,9 +80,9 @@ from .validator import CompatibilityValidator
 
 
 # Various modules use logging. Configure as you see fit.
-# import logging
-# import sys
-# logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+#import logging
+#import sys
+#logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
 def main():
@@ -103,7 +103,7 @@ def main():
         help="Path or version number of the old schema. Defaults to 'latest-stable'.",
     )
     parser.add_argument("after", help="Path or version number of the new schema.")
-    parser.add_argument("--cache", help="Path to the schema cache directory.")
+    parser.add_argument("--cache", default="schema_cache", help="Path to the schema cache directory.")
     parser.add_argument("--config", help="Path to the config.toml file.")
     parser.add_argument("--info", nargs="*", action="append", help="A finding to assign an info severity to.")
     parser.add_argument("--warning", nargs="*", action="append", help="A finding to assign a warning severity to.")


### PR DESCRIPTION
This PR adds a default cache location to be used by the backwards compatibility validator.

Without it, the validator was making a request to the OCSF server every time, causing CI jobs to intermittently fail when the server was being unresponsive.