### PR TITLE
Fixing a bug in ocsf.schema.json.names_to_keys

### DIFF
--- a/src/ocsf/schema/json.py
+++ b/src/ocsf/schema/json.py
@@ -57,13 +57,18 @@ def keys_to_names(d: dict[str, Any]) -> dict[str, Any]:
 
 def names_to_keys(d: dict[str, Any]) -> dict[str, Any]:
     """Transform Python-friendly names to OCSF property names in JSON."""
+    ops: list[tuple[str, str]] = []
+
     for k, v in d.items():
         if k in _NAME_TRANSFORMS:
-            d[_NAME_TRANSFORMS[k]] = d[k]
-            del d[k]
+            ops.append((k, _NAME_TRANSFORMS[k]))
 
-        if isinstance(k, dict):
-            d[k] = names_to_keys(v)
+        if isinstance(v, dict):
+            d[k] = names_to_keys(cast(dict[str, Any], v))
+
+    for op in ops:
+        d[op[1]] = d[op[0]]
+        del d[op[0]]
 
     return d
 

--- a/src/ocsf/validate/compatibility/__main__.py
+++ b/src/ocsf/validate/compatibility/__main__.py
@@ -80,9 +80,9 @@ from .validator import CompatibilityValidator
 
 
 # Various modules use logging. Configure as you see fit.
-#import logging
-#import sys
-#logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+# import logging
+# import sys
+# logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
 def main():

--- a/tests/ocsf/schema/test_key_xforms.py
+++ b/tests/ocsf/schema/test_key_xforms.py
@@ -1,0 +1,53 @@
+from ocsf.schema.json import names_to_keys, keys_to_names
+
+
+def test_names_to_keys():
+    data = {
+        "foo": "bar",
+        "deprecated": {
+            "since": "blah",
+            "message": "meh",
+        },
+        "baz": {
+            "qux": "quux",
+            "include_": "grault",
+        },
+    }
+
+    assert names_to_keys(data) == {
+        "foo": "bar",
+        "@deprecated": {
+            "since": "blah",
+            "message": "meh",
+        },
+        "baz": {
+            "qux": "quux",
+            "$include": "grault",
+        },
+    }
+
+
+def test_keys_to_names():
+    data = {
+        "foo": "bar",
+        "@deprecated": {
+            "since": "blah",
+            "message": "meh",
+        },
+        "baz": {
+            "qux": "quux",
+            "$include": "grault",
+        },
+    }
+
+    assert keys_to_names(data) == {
+        "foo": "bar",
+        "deprecated": {
+            "since": "blah",
+            "message": "meh",
+        },
+        "baz": {
+            "qux": "quux",
+            "include_": "grault",
+        },
+    }


### PR DESCRIPTION
I noticed a bug in the `names_to_keys` function. It should have been caught by a unit test, but I haven't written tests for most of the `ocsf.schema` package (the package consists mostly of dataclasses).

This PR fixes the bug and adds a test to catch it in the future.