### PR TITLE
Allowing "bugfix" changes to requirements

### DIFF
--- a/src/ocsf/validate/compatibility/increased_requirement.py
+++ b/src/ocsf/validate/compatibility/increased_requirement.py
@@ -26,6 +26,7 @@ valid, breaking backwards compatibility. If you wish to increase the strength of
 the requirement, you may change the requirement from optional to recommended
 without breaking backwards compatibility."""
 
+_ALLOWED = ["category_uid", "activity_id", "class_uid"]
 
 class NoIncreasedRequirementsRule(Rule[ChangedSchema]):
     def metadata(self):
@@ -37,7 +38,7 @@ class NoIncreasedRequirementsRule(Rule[ChangedSchema]):
             if isinstance(event, ChangedEvent):
                 for attr_name, attr in event.attributes.items():
                     if isinstance(attr, ChangedAttr):
-                        if isinstance(attr.requirement, Change) and attr.requirement.after == "required":
+                        if isinstance(attr.requirement, Change) and attr.requirement.after == "required" and attr_name not in _ALLOWED:
                             findings.append(
                                 IncreasedRequirementFinding(
                                     OcsfElementType.EVENT,

--- a/tests/ocsf/validate/compatibility/test_increased_requirement.py
+++ b/tests/ocsf/validate/compatibility/test_increased_requirement.py
@@ -36,3 +36,19 @@ def test_increased_requirement_object():
     findings = rule.validate(s)
     assert len(findings) == 1
     assert isinstance(findings[0], IncreasedRequirementFinding)
+
+def test_increased_requirement_event_bugfix():
+    """Test that the rule allows 'bugfix' increases to requirements for key attributes defined on base_event."""
+    s = ChangedSchema(
+        classes={
+            "process_activity": ChangedEvent(
+                attributes={
+                    "activity_id": ChangedAttr(requirement=Change("recommended", "required")),
+                }
+            ),
+        }
+    )
+
+    rule = NoIncreasedRequirementsRule()
+    findings = rule.validate(s)
+    assert len(findings) == 0


### PR DESCRIPTION
This PR modifies the behavior of the `NoIncreasedRequirements` rule in the backwards compatibility validator.

It allows increasing the requirement of certain fixed attributes of `base_event` necessary for the schema:
* `activity_id`
* `class_uid`
* `category_uid`

