### PR TITLE
Allow narrowing types from string_t to file_path_t

### DIFF
--- a/src/ocsf/schema/model.py
+++ b/src/ocsf/schema/model.py
@@ -69,7 +69,7 @@ class OcsfAttr(OcsfModel):
     type_name: Optional[str] = None
 
     def is_object(self) -> bool:
-        return self.type[-2:] != "_t" 
+        return self.type[-2:] != "_t"
 
     def is_primitive(self) -> bool:
         return not self.is_object()

--- a/tests/ocsf/validate/compatibility/test_changed_type.py
+++ b/tests/ocsf/validate/compatibility/test_changed_type.py
@@ -59,3 +59,26 @@ def test_int_to_long():
     rule = NoChangedTypesRule()
     findings = rule.validate(s)
     assert len(findings) == 0
+
+
+def test_str_to_filepath():
+    """Test that changing from string_t to file_path_t is allowed."""
+    s = ChangedSchema(
+        objects={
+            "process_activity": ChangedObject(
+                attributes={
+                    "process_name": ChangedAttr(type=Change("string_t", "file_path_t")),
+                }
+            ),
+        },
+        classes={
+            "process_activity": ChangedEvent(
+                attributes={
+                    "process_name": ChangedAttr(type=Change("string_t", "file_path_t")),
+                }
+            ),
+        },
+    )
+    rule = NoChangedTypesRule()
+    findings = rule.validate(s)
+    assert len(findings) == 0


### PR DESCRIPTION
PR #1326 reintroduced `file_path_t` and reassigned several `string_t` attributes to `file_path_t`. This is technically type narrowing and not backwards compatible, but it was decided to allow this change on the OCSF Tuesday call. In the future, we may want to limit this change to OCSF 1.4 -> 1.5.