### PR TITLE
Adding support to custom extension paths to compilation

### DIFF
--- a/src/ocsf/compile/__main__.py
+++ b/src/ocsf/compile/__main__.py
@@ -15,6 +15,10 @@ options:
                         The short path name (e.g. 'windows') of an extension to be enabled (defaults to all)
   --ignore-extension [IGNORE_EXTENSION ...]
                         The short path name of an extension to be disabled
+  --extension-path [EXTENSION_PATH ...]
+                        Path to a single extension to be loaded. Only needed if the extension is outside of the repository.
+  --extensions-path [EXTENSIONS_PATH ...]
+                        Path to an extra directory of extensions to be loaded. Only needed if the extensions are outside of the repository.
   --prefix-extensions   Prefix object and event names and any attributes that reference them as their type with the extension name
   --no-prefix-extensions
                         Do not prefix object and event names and any attributes that reference them as their type with the extension name
@@ -43,7 +47,7 @@ Build the schema with only the windows extension enabled:
 
 from argparse import ArgumentParser
 
-from ocsf.repository import read_repo
+from ocsf.repository import read_repo, add_extension, add_extensions
 from ocsf.schema import to_json
 
 from .compiler import Compilation
@@ -61,6 +65,16 @@ def main():
         help="The short path name (e.g. 'windows') of an extension to be enabled (defaults to all)",
     )
     parser.add_argument("--ignore-extension", nargs="*", help="The short path name of an extension to be disabled")
+    parser.add_argument(
+        "--extension-path",
+        nargs="*",
+        help="Path to a single extension to be loaded. Only needed if the extension is outside of the repository.",
+    )
+    parser.add_argument(
+        "--extensions-path",
+        nargs="*",
+        help="Path to an extra directory of extensions to be loaded. Only needed if the extensions are outside of the repository.",
+    )
     parser.add_argument(
         "--prefix-extensions",
         default=True,
@@ -116,6 +130,15 @@ def main():
     options.set_observable = args.set_observable
 
     repo = read_repo(args.path, preserve_raw_data=False)
+
+    if args.extension_path:
+        for path in args.extension_path:
+            add_extension(path, repo, preserve_raw_data=False)
+
+    if args.extensions_path:
+        for path in args.extensions_path:
+            add_extensions(path, repo, preserve_raw_data=False)
+
     compiler = Compilation(repo, options)
 
     print(to_json(compiler.build()))

--- a/src/ocsf/repository/__init__.py
+++ b/src/ocsf/repository/__init__.py
@@ -42,7 +42,7 @@ from .helpers import (
     path_defn_t,
 )
 from .repository import Repository, DefinitionFile
-from .reader import read_repo
+from .reader import read_repo, add_extensions, add_extension
 
 __all__ = [
     "AnyDefinition",
@@ -78,6 +78,8 @@ __all__ = [
     "SpecialFiles",
     "TypeDefn",
     "VersionDefn",
+    "add_extension",
+    "add_extensions",
     "as_path",
     "category",
     "categoryless",

--- a/src/ocsf/repository/reader.py
+++ b/src/ocsf/repository/reader.py
@@ -4,6 +4,8 @@ import json
 import dacite
 
 from pathlib import Path
+from typing import Callable
+
 from .repository import Repository, DefinitionFile
 from .definitions import AnyDefinition
 from .helpers import REPO_PATHS, RepoPaths, Pathlike, sanitize_path, path_defn_t
@@ -27,18 +29,28 @@ def _to_defn(path: Pathlike, raw_data: str, preserve_raw_data: bool) -> Definiti
     return defn
 
 
-def _walk_path(path: Path, repo: Repository, preserve_raw_data: bool) -> None:
+RenameFn = Callable[[Path], Path]
+
+
+def _walk_path(path: Path, repo: Repository, preserve_raw_data: bool, rename_fn: RenameFn | None = None) -> None:
     """Recursively walk a directory, reading schema definition files into a Repository."""
+
+    assert path.is_dir(), "Path must be a directory."
+
     for entry in path.iterdir():
         if entry.is_file() and entry.suffix == ".json":
             with open(entry) as file:
-                defn = _to_defn(entry, file.read(), preserve_raw_data)
-                repo[sanitize_path(entry)] = defn
+                if rename_fn is not None:
+                    dest = rename_fn(entry)
+                else:
+                    dest = entry
+                defn = _to_defn(dest, file.read(), preserve_raw_data)
+                repo[sanitize_path(dest)] = defn
 
         elif entry.is_dir() and (
             entry.name in REPO_PATHS or entry.parent.name in REPO_PATHS or RepoPaths.EVENTS.value in entry.parts
         ):
-            _walk_path(entry, repo, preserve_raw_data)
+            _walk_path(entry, repo, preserve_raw_data, rename_fn)
 
 
 def read_repo(path: Pathlike, preserve_raw_data: bool = False) -> Repository:
@@ -50,3 +62,27 @@ def read_repo(path: Pathlike, preserve_raw_data: bool = False) -> Repository:
     _walk_path(path, repo, preserve_raw_data)
 
     return repo
+
+
+def add_extensions(extn_path: Pathlike, repo: Repository, preserve_raw_data: bool = False) -> None:
+    """Add a custom extensions directory to a Repository."""
+    if not isinstance(extn_path, Path):
+        extn_path = Path(extn_path)
+
+    def _rename_extensions(path: Path) -> Path:
+        return RepoPaths.EXTENSIONS.value / path.relative_to(extn_path)
+
+    _walk_path(extn_path, repo, preserve_raw_data, rename_fn=_rename_extensions)
+
+
+def add_extension(extn_path: Pathlike, repo: Repository, preserve_raw_data: bool = False) -> None:
+    """Add a custom extension to a Repository by its path."""
+    if not isinstance(extn_path, Path):
+        extn_path = Path(extn_path)
+
+    extn_base = Path(RepoPaths.EXTENSIONS.value, extn_path.name)
+
+    def _rename_extension(path: Path) -> Path:
+        return extn_base / path.relative_to(extn_path)
+
+    _walk_path(extn_path, repo, preserve_raw_data, rename_fn=_rename_extension)

--- a/src/ocsf/schema/model.py
+++ b/src/ocsf/schema/model.py
@@ -69,7 +69,7 @@ class OcsfAttr(OcsfModel):
     type_name: Optional[str] = None
 
     def is_object(self) -> bool:
-        return self.type[-2:] != "_t" 
+        return self.type[-2:] != "_t"
 
     def is_primitive(self) -> bool:
         return not self.is_object()


### PR DESCRIPTION
This PR adds the ability to point to a custom `extensions` path or a single custom extension (similar to the OCSF server's `-e` argument) that are stored separately from the repository being compiled.