### PR TITLE
Avoid an unnecessary runtime calculation

### DIFF
--- a/src/ocsf/compile/compiler.py
+++ b/src/ocsf/compile/compiler.py
@@ -59,29 +59,22 @@ class Compilation:
             [
                 # Expand annotations in profiles and includes.
                 AnnotationPlanner(self._proto, options),
-
                 # Set the extension property of objects and events introduced to
                 # core by extensions.
                 MarkExtensionPlanner(self._proto, options),
-
                 # Set the profile name of attributes to the profile that adds
                 # them to the object or event.
                 MarkProfilePlanner(self._proto, options),
-
                 # Process $include directives.
                 IncludePlanner(self._proto, options),
-
                 # Process extends directives.
                 ExtendsPlanner(self._proto, options),
-
                 # Build the observable type_id enum based on values found across
                 # the schema.
                 BuildObservableTypesPlanner(self._proto, options),
-
                 # Process definitions in extensions that modify records in core
                 # (reverse extends?).
                 ExtensionMergePlanner(self._proto, options),
-
                 # Remove attributes from deactivated profiles.
                 ExcludeProfileAttrsPlanner(self._proto, options),
             ],
@@ -93,7 +86,6 @@ class Compilation:
             [
                 # Build the UID enumerations (type_id, class_uid, etc.).
                 UidPlanner(self._proto, options),
-
                 # Complete missing attribute details using dictionary.json.
                 DictionaryPlanner(self._proto, options),
             ],
@@ -103,28 +95,22 @@ class Compilation:
                 # references to them. Only performed if
                 # options.prefix_extensions is True.
                 ExtensionPrefixPlanner(self._proto, options),
-
                 # For attributes with object types, change type to object and
                 # populate the object_type and object_name properties to match
                 # the output of the OCSF server. Only performed if
                 # options.set_object_types is True.
                 ObjectTypePlanner(self._proto, options),
-
                 # Build the sibling _name fields for UID enumerations.
                 UidSiblingPlanner(self._proto, options),
-
                 # Apply the datetime synthetic profile.
                 DateTimePlanner(self._proto, options),
-
                 # Set the observable property of attributes to the corresponding
                 # observable.type_id value to make building the observables
                 # attribute of records easier. Only performed if
                 # options.set_observable is True.
                 MarkObservablesPlanner(self._proto, options),
-
                 # Map events to categories in the categories.json file.
                 MapEventToCategoryPlanner(self._proto, options),
-
                 # Copy records that are ONLY defined in extensions to the core
                 # schema so that they are included by ProtoSchema.schema().
                 ExtensionCopyPlanner(self._proto, options),

--- a/src/ocsf/repository/helpers.py
+++ b/src/ocsf/repository/helpers.py
@@ -29,7 +29,8 @@ class RepoPaths(StrEnum):
     PROFILES = "profiles"
 
 
-REPO_PATHS = tuple([e.value for e in RepoPaths])
+REPO_PATHS = ("objects", "events", "extensions", "includes", "profiles")
+"""Tuple containing strings of the values in the RepoPaths enum."""
 
 
 class SpecialFiles(StrEnum):
@@ -46,7 +47,8 @@ class SpecialFiles(StrEnum):
         return path in [e.value for e in SpecialFiles]
 
 
-SPECIAL_FILES = tuple([e.value for e in SpecialFiles])
+SPECIAL_FILES = ("dictionary.json", "categories.json", "version.json", "extension.json", "objects/observable.json")
+"""Tuple containing strings of the values in the SpecialFiles enum."""
 
 
 def sanitize_path(*path: Pathlike) -> RepoPath:

--- a/src/ocsf/validate/compatibility/increased_requirement.py
+++ b/src/ocsf/validate/compatibility/increased_requirement.py
@@ -28,6 +28,7 @@ without breaking backwards compatibility."""
 
 _ALLOWED = ["category_uid", "activity_id", "class_uid"]
 
+
 class NoIncreasedRequirementsRule(Rule[ChangedSchema]):
     def metadata(self):
         return RuleMetadata("No increased requirements", description=_RULE_DESCRIPTION)
@@ -38,7 +39,11 @@ class NoIncreasedRequirementsRule(Rule[ChangedSchema]):
             if isinstance(event, ChangedEvent):
                 for attr_name, attr in event.attributes.items():
                     if isinstance(attr, ChangedAttr):
-                        if isinstance(attr.requirement, Change) and attr.requirement.after == "required" and attr_name not in _ALLOWED:
+                        if (
+                            isinstance(attr.requirement, Change)
+                            and attr.requirement.after == "required"
+                            and attr_name not in _ALLOWED
+                        ):
                             findings.append(
                                 IncreasedRequirementFinding(
                                     OcsfElementType.EVENT,

--- a/tests/ocsf/repository/test_helpers.py
+++ b/tests/ocsf/repository/test_helpers.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ocsf.repository.helpers import path_defn_t, RepoPaths, SpecialFiles
+from ocsf.repository.helpers import path_defn_t, RepoPaths, SpecialFiles, REPO_PATHS, SPECIAL_FILES
 from ocsf.repository.definitions import (
     ObjectDefn,
     EventDefn,
@@ -48,3 +48,23 @@ def test_path_defn_t():
         path_defn_t("extensions/events/foo.json")
     with pytest.raises(ValueError):
         path_defn_t("extensions/extn/foo.json")
+
+
+def test_repo_path_tuple_values():
+    """Verify that the REPO_PATHS tuple contains the same values as the RepoPaths enum."""
+    enum_paths = [x.value for x in RepoPaths]
+    for rp in REPO_PATHS:
+        assert rp in enum_paths, f"REPO_PATH tuple contains `{rp}` which is not in the RepoPaths Enum"
+
+    for e in RepoPaths:
+        assert e.value in REPO_PATHS, f"REPO_PATH tuple is missing `{e.value}`"
+
+
+def test_special_files_tuple_values():
+    """Verify that the REPO_PATHS tuple contains the same values as the RepoPaths enum."""
+    enum_paths = [x.value for x in SpecialFiles]
+    for rp in SPECIAL_FILES:
+        assert rp in enum_paths, f"SPECIAL_FILES tuple contains `{rp}` which is not in the SpecialFiles Enum"
+
+    for e in SpecialFiles:
+        assert e.value in SPECIAL_FILES, f"SPECIAL_FILES tuple is missing `{e.value}`"

--- a/tests/ocsf/validate/compatibility/test_increased_requirement.py
+++ b/tests/ocsf/validate/compatibility/test_increased_requirement.py
@@ -37,6 +37,7 @@ def test_increased_requirement_object():
     assert len(findings) == 1
     assert isinstance(findings[0], IncreasedRequirementFinding)
 
+
 def test_increased_requirement_event_bugfix():
     """Test that the rule allows 'bugfix' increases to requirements for key attributes defined on base_event."""
     s = ChangedSchema(


### PR DESCRIPTION
Rather than compute ``REPO_PATHS `` and  ``SPECIAL_FILES `` tuples at runtime every time the tool fires up, just write out the values.

To ensure that the related   ``RepoPaths `` and  ``SpecialFiles `` enums and these tuples stay in sync, two unittests are added.

Additionally, I ran ``ruff format`` which seems to have changed several files (I had assumed formatting was enforced by CI tooling).