### PR TITLE
Ensure ruff format check is run & fix code smells

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+poetry.lock linguist-generated=true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           source $VENV
           poetry run ruff check
+          poetry run ruff format --check
 
   type-checking:
     runs-on: ubuntu-latest

--- a/poetry.lock
+++ b/poetry.lock
@@ -129,28 +129,29 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "pytest-mock (>=3.12)"]
 
 [[package]]
 name = "ruff"
-version = "0.4.9"
+version = "0.8.6"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.4.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b262ed08d036ebe162123170b35703aaf9daffecb698cd367a8d585157732991"},
-    {file = "ruff-0.4.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:98ec2775fd2d856dc405635e5ee4ff177920f2141b8e2d9eb5bd6efd50e80317"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4555056049d46d8a381f746680db1c46e67ac3b00d714606304077682832998e"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e91175fbe48f8a2174c9aad70438fe9cb0a5732c4159b2a10a3565fea2d94cde"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e8e7b95673f22e0efd3571fb5b0cf71a5eaaa3cc8a776584f3b2cc878e46bff"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2d45ddc6d82e1190ea737341326ecbc9a61447ba331b0a8962869fcada758505"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:78de3fdb95c4af084087628132336772b1c5044f6e710739d440fc0bccf4d321"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:06b60f91bfa5514bb689b500a25ba48e897d18fea14dce14b48a0c40d1635893"},
-    {file = "ruff-0.4.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88bffe9c6a454bf8529f9ab9091c99490578a593cc9f9822b7fc065ee0712a06"},
-    {file = "ruff-0.4.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:673bddb893f21ab47a8334c8e0ea7fd6598ecc8e698da75bcd12a7b9d0a3206e"},
-    {file = "ruff-0.4.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8c1aff58c31948cc66d0b22951aa19edb5af0a3af40c936340cd32a8b1ab7438"},
-    {file = "ruff-0.4.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:784d3ec9bd6493c3b720a0b76f741e6c2d7d44f6b2be87f5eef1ae8cc1d54c84"},
-    {file = "ruff-0.4.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:732dd550bfa5d85af8c3c6cbc47ba5b67c6aed8a89e2f011b908fc88f87649db"},
-    {file = "ruff-0.4.9-py3-none-win32.whl", hash = "sha256:8064590fd1a50dcf4909c268b0e7c2498253273309ad3d97e4a752bb9df4f521"},
-    {file = "ruff-0.4.9-py3-none-win_amd64.whl", hash = "sha256:e0a22c4157e53d006530c902107c7f550b9233e9706313ab57b892d7197d8e52"},
-    {file = "ruff-0.4.9-py3-none-win_arm64.whl", hash = "sha256:5d5460f789ccf4efd43f265a58538a2c24dbce15dbf560676e430375f20a8198"},
-    {file = "ruff-0.4.9.tar.gz", hash = "sha256:f1cb0828ac9533ba0135d148d214e284711ede33640465e706772645483427e3"},
+    {file = "ruff-0.8.6-py3-none-linux_armv6l.whl", hash = "sha256:defed167955d42c68b407e8f2e6f56ba52520e790aba4ca707a9c88619e580e3"},
+    {file = "ruff-0.8.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:54799ca3d67ae5e0b7a7ac234baa657a9c1784b48ec954a094da7c206e0365b1"},
+    {file = "ruff-0.8.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e88b8f6d901477c41559ba540beeb5a671e14cd29ebd5683903572f4b40a9807"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0509e8da430228236a18a677fcdb0c1f102dd26d5520f71f79b094963322ed25"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91a7ddb221779871cf226100e677b5ea38c2d54e9e2c8ed847450ebbdf99b32d"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:248b1fb3f739d01d528cc50b35ee9c4812aa58cc5935998e776bf8ed5b251e75"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:bc3c083c50390cf69e7e1b5a5a7303898966be973664ec0c4a4acea82c1d4315"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52d587092ab8df308635762386f45f4638badb0866355b2b86760f6d3c076188"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:61323159cf21bc3897674e5adb27cd9e7700bab6b84de40d7be28c3d46dc67cf"},
+    {file = "ruff-0.8.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ae4478b1471fc0c44ed52a6fb787e641a2ac58b1c1f91763bafbc2faddc5117"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0c000a471d519b3e6cfc9c6680025d923b4ca140ce3e4612d1a2ef58e11f11fe"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:9257aa841e9e8d9b727423086f0fa9a86b6b420fbf4bf9e1465d1250ce8e4d8d"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:45a56f61b24682f6f6709636949ae8cc82ae229d8d773b4c76c09ec83964a95a"},
+    {file = "ruff-0.8.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:496dd38a53aa173481a7d8866bcd6451bd934d06976a2505028a50583e001b76"},
+    {file = "ruff-0.8.6-py3-none-win32.whl", hash = "sha256:e169ea1b9eae61c99b257dc83b9ee6c76f89042752cb2d83486a7d6e48e8f764"},
+    {file = "ruff-0.8.6-py3-none-win_amd64.whl", hash = "sha256:f1d70bef3d16fdc897ee290d7d20da3cbe4e26349f62e8a0274e7a3f4ce7a905"},
+    {file = "ruff-0.8.6-py3-none-win_arm64.whl", hash = "sha256:7d7fc2377a04b6e04ffe588caad613d0c460eb2ecba4c0ccbbfe2bc973cbc162"},
+    {file = "ruff-0.8.6.tar.gz", hash = "sha256:dcad24b81b62650b0eb8814f576fc65cfee8674772a6e24c9b747911801eeaa5"},
 ]
 
 [[package]]
@@ -181,4 +182,4 @@ tests = ["pytest", "pytest-cov"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "0cd39969388c7ac127c91256c9bb7e231425ea3b3c6a06d3d00df7d270ff5068"
+content-hash = "99aa9443a55dad06819bd89dfd7636d445435307982ba0ff7fb478da2c22128c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ description = "Tools for working with the OCSF schema"
 authors = ["Jeremy Fisher <jeremy@query.ai>"]
 readme = "README.md"
 license = "Apache-2.0"
-packages = [
-    { include = "ocsf", from = "src" },
-]
+packages = [{ include = "ocsf", from = "src" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"
@@ -16,7 +14,7 @@ semver = "^3.0.2"
 termcolor = "^2.4.0"
 
 [tool.poetry.group.dev.dependencies]
-ruff = "^0.4.2"
+ruff = "^0.8.4"
 pyright = "^1.1.361"
 pytest = "^8.2.0"
 pytest-env = "^1.1.3"
@@ -34,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.pyright]
 typeCheckingMode = "strict"
 strict = ["src/ocsf"]
-reportPrivateUsage = false # Unit testing private/protected things is A-OK in my book
+reportPrivateUsage = false  # Unit testing private/protected things is A-OK in my book
 
 [tool.pytest.ini_options]
 markers = [
@@ -48,3 +46,25 @@ COMPILE_SCHEMA_PATH = "tests/ocsf/compile/ocsf-schema.json"
 
 [tool.ruff]
 line-length = 120
+exclude = ["*.pyi", "*.pyc", "*.pyd"]
+
+[tool.ruff.lint]
+select = [
+    "E",  # Pycodestyle Errors
+    "W",  # Pycodestyle Warnings
+    "F",  # PyFlakes rules
+    "B",  # Bugbear rules (likely bugs & design problems in your code)
+    "N",  # Pep8 naming rules
+    "UP", # Prefer upgraded Python syntax
+    "I",  # Import sorting
+]
+
+# Allow unused variables named "_" or starting with "_"
+dummy-variable-rgx = "^_$"
+
+# Select the classes of fixable errors
+fixable = ["E", "F", "W", "N", "UP", "I"]
+
+unfixable = [
+    "B", # Avoid trying to fix flake8-bugbear (`B`) violations.
+]

--- a/src/ocsf/api/client.py
+++ b/src/ocsf/api/client.py
@@ -14,32 +14,30 @@ TODO:
   API. This could be replaced with a more robust OpenAPI client.
 """
 
-import logging
 import json
-
+import logging
 from copy import copy
 from dataclasses import dataclass
-from urllib.request import urlopen
-from urllib.parse import urljoin
-from typing import Optional, Any, cast, ClassVar
-from semver import Version
 from pathlib import Path
+from typing import Any, ClassVar, Optional, cast
+from urllib.parse import urljoin
+from urllib.request import urlopen
 
 from dacite import from_dict
+from semver import Version
 
 from ocsf.schema import (
-    OcsfSchema,
     OcsfCategory,
-    OcsfProfile,
     OcsfExtension,
+    OcsfProfile,
+    OcsfSchema,
     SchemaOptions,
     WithAttributes,
-    from_json,
     from_file,
-    to_file,
+    from_json,
     resolve_object_types,
+    to_file,
 )
-
 
 LOG = logging.getLogger(__name__)
 
@@ -96,7 +94,7 @@ class OcsfApiClient:
         self,
         base_url: Optional[str] = None,
         cache_dir: Optional[str | Path] = None,
-        schema_options: SchemaOptions = SchemaOptions(),
+        schema_options: SchemaOptions | None = None,
         fetch_profiles: bool = True,
         fetch_extensions: bool = True,
         fetch_categories: bool = True,
@@ -115,7 +113,11 @@ class OcsfApiClient:
         self._fetch_profiles = fetch_profiles
         self._fetch_extensions = fetch_extensions
         self._fetch_categories = fetch_categories
-        self._schema_options = schema_options
+
+        if schema_options is None:
+            self._schema_options = SchemaOptions()
+        else:
+            self._schema_options = schema_options
 
         if cache_dir is not None and not isinstance(cache_dir, Path):
             self._cache_dir = Path(cache_dir)

--- a/src/ocsf/compare/__init__.py
+++ b/src/ocsf/compare/__init__.py
@@ -1,5 +1,4 @@
 from .compare import compare, compare_dict
-
 from .model import (
     Addition,
     Change,

--- a/src/ocsf/compare/__main__.py
+++ b/src/ocsf/compare/__main__.py
@@ -10,14 +10,15 @@ Example:
 
 from argparse import ArgumentParser
 from typing import cast
+
 from termcolor import colored
 
-from ocsf.util import get_schema
 from ocsf.schema import OcsfSchema
+from ocsf.util import get_schema
 
-from .model import ChangedModel
 from .compare import compare
 from .formatter import format
+from .model import ChangedModel
 
 
 def main():

--- a/src/ocsf/compare/compare.py
+++ b/src/ocsf/compare/compare.py
@@ -12,28 +12,28 @@ result is a dictionary will always have all of the keys from both dictionaries,
 with the values being the differences of the corresponding keys.
 """
 
+from types import NoneType, UnionType
 from typing import (
-    TypeVar,
-    TypeGuard,
-    Union,
-    get_args,
-    get_type_hints,
-    get_origin,
     Any,
+    TypeGuard,
+    TypeVar,
+    Union,
     cast,
+    get_args,
+    get_origin,
+    get_type_hints,
 )
-from types import UnionType, NoneType
 
 from ocsf.schema import OcsfModel
-from .model import (
-    Difference,
-    Addition,
-    Removal,
-    Change,
-    NoChange,
-)
-from .factory import create_diff
 
+from .factory import create_diff
+from .model import (
+    Addition,
+    Change,
+    Difference,
+    NoChange,
+    Removal,
+)
 
 T = TypeVar("T")
 K = TypeVar("K")
@@ -141,7 +141,7 @@ def compare(old_val: T, new_val: T) -> Difference[T]:
     Returns:
         A suitable Difference object representing the comparison of the two values.
     """
-    if isinstance(old_val, OcsfModel) and type(old_val) == type(new_val):
+    if isinstance(old_val, OcsfModel) and type(old_val) is type(new_val):
         ret = create_diff(old_val)
 
         for attr, value in get_type_hints(old_val).items():

--- a/src/ocsf/compare/factory.py
+++ b/src/ocsf/compare/factory.py
@@ -16,6 +16,7 @@ from typing import cast
 
 from ocsf.schema import (
     OcsfAttr,
+    OcsfCategory,
     OcsfDeprecationInfo,
     OcsfEnumMember,
     OcsfEvent,
@@ -26,10 +27,11 @@ from ocsf.schema import (
     OcsfT,
     OcsfType,
     OcsfVersion,
-    OcsfCategory,
 )
+
 from .model import (
     ChangedAttr,
+    ChangedCategory,
     ChangedDeprecationInfo,
     ChangedEnumMember,
     ChangedEvent,
@@ -40,7 +42,6 @@ from .model import (
     ChangedSchema,
     ChangedType,
     ChangedVersion,
-    ChangedCategory,
 )
 
 

--- a/src/ocsf/compare/formatter.py
+++ b/src/ocsf/compare/formatter.py
@@ -4,13 +4,14 @@ This modules prints a ChangedModel to stdout in a format similar to diff with
 color coding.
 """
 
+from textwrap import shorten
 from typing import Any, cast
 
-from textwrap import shorten
 from termcolor import colored
 
 from ocsf.schema import OcsfT
-from .model import ChangedModel, Difference, SimpleDifference, Addition, Change, Removal
+
+from .model import Addition, Change, ChangedModel, Difference, Removal, SimpleDifference
 
 
 def _display(value: Any, line_length: int = 80) -> str:

--- a/src/ocsf/compare/model.py
+++ b/src/ocsf/compare/model.py
@@ -44,17 +44,17 @@ the appropriate dict and NoChange. See ChangedAttr.enum for an example.
 
 """
 
-from dataclasses import dataclass, field
-from typing import Any, TypeVar, Generic, Optional
 from abc import ABC
+from dataclasses import dataclass, field
+from typing import Any, Generic, Optional, TypeVar
 
 from ocsf.schema import (
     OcsfAttr,
+    OcsfCategory,
     OcsfDeprecationInfo,
     OcsfEnumMember,
     OcsfEvent,
     OcsfExtension,
-    OcsfCategory,
     OcsfObject,
     OcsfProfile,
     OcsfSchema,
@@ -62,7 +62,6 @@ from ocsf.schema import (
     OcsfType,
     OcsfVersion,
 )
-
 
 T = TypeVar("T", covariant=True)
 

--- a/src/ocsf/compile/__init__.py
+++ b/src/ocsf/compile/__init__.py
@@ -1,6 +1,5 @@
-from .options import CompilationOptions
 from .compiler import Compilation
 from .merge import MergeResult, merge
-
+from .options import CompilationOptions
 
 __all__ = ["CompilationOptions", "Compilation", "MergeResult", "merge"]

--- a/src/ocsf/compile/__main__.py
+++ b/src/ocsf/compile/__main__.py
@@ -16,17 +16,22 @@ options:
   --ignore-extension [IGNORE_EXTENSION ...]
                         The short path name of an extension to be disabled
   --extension-path [EXTENSION_PATH ...]
-                        Path to a single extension to be loaded. Only needed if the extension is outside of the repository.
+                        Path to a single extension to be loaded. Only needed if the extension is outside of
+                        the repository.
   --extensions-path [EXTENSIONS_PATH ...]
-                        Path to an extra directory of extensions to be loaded. Only needed if the extensions are outside of the repository.
-  --prefix-extensions   Prefix object and event names and any attributes that reference them as their type with the extension name
+                        Path to an extra directory of extensions to be loaded. Only needed if the extensions
+                        are outside of the repository.
+  --prefix-extensions   Prefix object and event names and any attributes that reference them as their type with the
+                        extension name
   --no-prefix-extensions
-                        Do not prefix object and event names and any attributes that reference them as their type with the extension name
+                        Do not prefix object and event names and any attributes that reference them as their type
+                        with the extension name
   --set-object-types    Set type to 'object' and object_type to the object name for type references to objects
   --no-set-object-types
                         Do not set type to 'object' and object_type to the object name for type references to objects
   --set-observable      Set the observable field on attributes to the corresponding Observable Type ID where applicable
-  --no-set-observable   Do not set the observable field on attributes to the corresponding Observable Type ID where applicable
+  --no-set-observable   Do not set the observable field on attributes to the corresponding Observable Type ID
+                        where applicable
 ```
 
 Examples:
@@ -47,7 +52,7 @@ Build the schema with only the windows extension enabled:
 
 from argparse import ArgumentParser
 
-from ocsf.repository import read_repo, add_extension, add_extensions
+from ocsf.repository import add_extension, add_extensions, read_repo
 from ocsf.schema import to_json
 
 from .compiler import Compilation
@@ -73,19 +78,28 @@ def main():
     parser.add_argument(
         "--extensions-path",
         nargs="*",
-        help="Path to an extra directory of extensions to be loaded. Only needed if the extensions are outside of the repository.",
+        help=(
+            "Path to an extra directory of extensions to be loaded. Only needed if the extensions are "
+            "outside of the repository."
+        ),
     )
     parser.add_argument(
         "--prefix-extensions",
         default=True,
         action="store_true",
-        help="Prefix object and event names and any attributes that reference them as their type with the extension name",
+        help=(
+            "Prefix object and event names and any attributes that reference them as their type "
+            "with the extension name"
+        ),
     )
     parser.add_argument(
         "--no-prefix-extensions",
         dest="prefix_extensions",
         action="store_false",
-        help="Do not prefix object and event names and any attributes that reference them as their type with the extension name",
+        help=(
+            "Do not prefix object and event names and any attributes that reference them as their "
+            "type with the extension name"
+        ),
     )
     parser.add_argument(
         "--set-object-types",

--- a/src/ocsf/compile/compiler.py
+++ b/src/ocsf/compile/compiler.py
@@ -10,30 +10,31 @@ Example:
 
 from typing import Optional
 
+from ocsf.repository import RepoPath, Repository
 from ocsf.schema import OcsfSchema
-from ocsf.repository import Repository, RepoPath
-from .options import CompilationOptions
-from .protoschema import ProtoSchema
-from .planners.planner import Operation, Planner
-from .planners.annotations import AnnotationPlanner
-from .planners.set_category import SetCategoryPlanner
-from .planners.extension import (
-    ExtensionMergePlanner,
-    ExtensionCopyPlanner,
-    MarkExtensionPlanner,
-    ExtensionPrefixPlanner,
-)
-from .planners.extends import ExtendsPlanner
-from .planners.include import IncludePlanner
-from .planners.profile import ExcludeProfileAttrsPlanner, MarkProfilePlanner
-from .planners.dictionary import DictionaryPlanner
-from .planners.uid import UidPlanner
-from .planners.object_type import ObjectTypePlanner
-from .planners.uid_names import UidSiblingPlanner
-from .planners.datetime import DateTimePlanner
-from .planners.observable import MarkObservablesPlanner, BuildObservableTypesPlanner
-from .planners.category_events import MapEventToCategoryPlanner
+
 from .merge import MergeResult
+from .options import CompilationOptions
+from .planners.annotations import AnnotationPlanner
+from .planners.category_events import MapEventToCategoryPlanner
+from .planners.datetime import DateTimePlanner
+from .planners.dictionary import DictionaryPlanner
+from .planners.extends import ExtendsPlanner
+from .planners.extension import (
+    ExtensionCopyPlanner,
+    ExtensionMergePlanner,
+    ExtensionPrefixPlanner,
+    MarkExtensionPlanner,
+)
+from .planners.include import IncludePlanner
+from .planners.object_type import ObjectTypePlanner
+from .planners.observable import BuildObservableTypesPlanner, MarkObservablesPlanner
+from .planners.planner import Operation, Planner
+from .planners.profile import ExcludeProfileAttrsPlanner, MarkProfilePlanner
+from .planners.set_category import SetCategoryPlanner
+from .planners.uid import UidPlanner
+from .planners.uid_names import UidSiblingPlanner
+from .protoschema import ProtoSchema
 
 FileOperations = dict[RepoPath, list[Operation]]
 CompilationOperations = list[FileOperations]
@@ -45,75 +46,76 @@ PlanningPhase = list[Planner]
 
 
 class Compilation:
-    def __init__(self, repo: Repository, options: CompilationOptions = CompilationOptions()):
+    def __init__(self, repo: Repository, options: CompilationOptions | None = None):
         self._operations: Optional[CompilationOperations] = None
         self._plan: Optional[CompilationPlan] = None
         self._mutations: Optional[CompilationMutations] = None
         self._schema: Optional[OcsfSchema] = None
         self._repo = repo
         self._proto = ProtoSchema(repo)
+        _options = CompilationOptions() if options is None else options
 
         # The arrangement of planners to phases is very important. If you think
         # it needs to change, you're probably wrong.
         self._planners: list[PlanningPhase] = [
             [
                 # Expand annotations in profiles and includes.
-                AnnotationPlanner(self._proto, options),
+                AnnotationPlanner(self._proto, _options),
                 # Set the extension property of objects and events introduced to
                 # core by extensions.
-                MarkExtensionPlanner(self._proto, options),
+                MarkExtensionPlanner(self._proto, _options),
                 # Set the profile name of attributes to the profile that adds
                 # them to the object or event.
-                MarkProfilePlanner(self._proto, options),
+                MarkProfilePlanner(self._proto, _options),
                 # Process $include directives.
-                IncludePlanner(self._proto, options),
+                IncludePlanner(self._proto, _options),
                 # Process extends directives.
-                ExtendsPlanner(self._proto, options),
+                ExtendsPlanner(self._proto, _options),
                 # Build the observable type_id enum based on values found across
                 # the schema.
-                BuildObservableTypesPlanner(self._proto, options),
+                BuildObservableTypesPlanner(self._proto, _options),
                 # Process definitions in extensions that modify records in core
                 # (reverse extends?).
-                ExtensionMergePlanner(self._proto, options),
+                ExtensionMergePlanner(self._proto, _options),
                 # Remove attributes from deactivated profiles.
-                ExcludeProfileAttrsPlanner(self._proto, options),
+                ExcludeProfileAttrsPlanner(self._proto, _options),
             ],
             [
                 # Set the category of events.
                 # TODO: Can this be performed in the prior phase?
-                SetCategoryPlanner(self._proto, options),
+                SetCategoryPlanner(self._proto, _options),
             ],
             [
                 # Build the UID enumerations (type_id, class_uid, etc.).
-                UidPlanner(self._proto, options),
+                UidPlanner(self._proto, _options),
                 # Complete missing attribute details using dictionary.json.
-                DictionaryPlanner(self._proto, options),
+                DictionaryPlanner(self._proto, _options),
             ],
             [
                 # Prefix the names of objects and events added by extensions
                 # with their extension name, and also update all attribute type
                 # references to them. Only performed if
                 # options.prefix_extensions is True.
-                ExtensionPrefixPlanner(self._proto, options),
+                ExtensionPrefixPlanner(self._proto, _options),
                 # For attributes with object types, change type to object and
                 # populate the object_type and object_name properties to match
                 # the output of the OCSF server. Only performed if
                 # options.set_object_types is True.
-                ObjectTypePlanner(self._proto, options),
+                ObjectTypePlanner(self._proto, _options),
                 # Build the sibling _name fields for UID enumerations.
-                UidSiblingPlanner(self._proto, options),
+                UidSiblingPlanner(self._proto, _options),
                 # Apply the datetime synthetic profile.
-                DateTimePlanner(self._proto, options),
+                DateTimePlanner(self._proto, _options),
                 # Set the observable property of attributes to the corresponding
                 # observable.type_id value to make building the observables
                 # attribute of records easier. Only performed if
                 # options.set_observable is True.
-                MarkObservablesPlanner(self._proto, options),
+                MarkObservablesPlanner(self._proto, _options),
                 # Map events to categories in the categories.json file.
-                MapEventToCategoryPlanner(self._proto, options),
+                MapEventToCategoryPlanner(self._proto, _options),
                 # Copy records that are ONLY defined in extensions to the core
                 # schema so that they are included by ProtoSchema.schema().
-                ExtensionCopyPlanner(self._proto, options),
+                ExtensionCopyPlanner(self._proto, _options),
             ],
         ]
 

--- a/src/ocsf/compile/debug.py
+++ b/src/ocsf/compile/debug.py
@@ -4,8 +4,8 @@ from pprint import pprint
 from ocsf.repository import read_repo
 
 from .compiler import Compilation
-from .planners.planner import Operation
 from .merge import MergeResult
+from .planners.planner import Operation
 
 
 def find_prereqs(compilation: Compilation, file: str, found: set[str] | None = None) -> set[str]:

--- a/src/ocsf/compile/merge.py
+++ b/src/ocsf/compile/merge.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import get_type_hints, cast, Optional, Any
+from typing import Any, Optional, cast, get_type_hints
 
 from ocsf.repository.definitions import DefinitionPart
 
@@ -200,7 +200,8 @@ def merge(
                 and options.merge_lists
             ):
                 simple = False
-                # TODO check to see if these can be cast to list[str] - are there any other types of lists in the JSON definitions?
+                # TODO check to see if these can be cast to list[str] - are there any other types of lists in
+                # the JSON definitions?
                 left_value = cast(list[Any], left_value)
                 right_value = cast(list[Any], right_value)
                 setattr(left, attr, list(set(left_value + right_value)))

--- a/src/ocsf/compile/options.py
+++ b/src/ocsf/compile/options.py
@@ -23,7 +23,7 @@ class CompilationOptions:
 
     set_object_types: bool = True
     """If True, set type to 'object' and object_type to the object name for type
-    references to objects, as per the original OCSF server. If False, the type 
+    references to objects, as per the original OCSF server. If False, the type
     field will refer directly to the object type.
     """
 

--- a/src/ocsf/compile/planners/annotations.py
+++ b/src/ocsf/compile/planners/annotations.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 
-from .planner import Operation, Planner, Analysis
-from ..merge import merge, MergeResult, MergeOptions
-from ..protoschema import ProtoSchema
+from ocsf.repository import AnyDefinition, AttrDefn, DefinitionFile, DefnWithAnnotations
 
-from ocsf.repository import DefinitionFile, DefnWithAnnotations, AttrDefn, AnyDefinition
+from ..merge import MergeOptions, MergeResult, merge
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/ocsf/compile/planners/category_events.py
+++ b/src/ocsf/compile/planners/category_events.py
@@ -1,12 +1,12 @@
 from copy import copy
 from dataclasses import dataclass
 
-from ocsf.repository import EventDefn, CategoriesDefn, CategoryDefn, DefinitionFile, AnyDefinition, SpecialFiles
+from ocsf.repository import AnyDefinition, CategoriesDefn, CategoryDefn, DefinitionFile, EventDefn, SpecialFiles
 
 from ..merge import MergeResult
-from ..protoschema import ProtoSchema
 from ..options import CompilationOptions
-from .planner import Operation, Planner, Analysis
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/ocsf/compile/planners/datetime.py
+++ b/src/ocsf/compile/planners/datetime.py
@@ -1,10 +1,11 @@
 from copy import deepcopy
 from dataclasses import dataclass
 
-from ocsf.repository import DefinitionFile, DefnWithAttrs, AttrDefn, AnyDefinition
+from ocsf.repository import AnyDefinition, AttrDefn, DefinitionFile, DefnWithAttrs
+
 from ..merge import MergeResult
 from ..protoschema import ProtoSchema
-from .planner import Operation, Planner, Analysis
+from .planner import Analysis, Operation, Planner
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/ocsf/compile/planners/dictionary.py
+++ b/src/ocsf/compile/planners/dictionary.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 
-from ..protoschema import ProtoSchema
-from ..merge import merge, MergeResult
+from ocsf.repository import AnyDefinition, AttrDefn, DefinitionFile, DefnWithAttrs, DictionaryDefn, SpecialFiles
 
-from .planner import Operation, Planner, Analysis
-from ocsf.repository import DefinitionFile, AnyDefinition, SpecialFiles, DictionaryDefn, AttrDefn, DefnWithAttrs
+from ..merge import MergeResult, merge
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/ocsf/compile/planners/extends.py
+++ b/src/ocsf/compile/planners/extends.py
@@ -1,21 +1,22 @@
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from ..protoschema import ProtoSchema
-from ..merge import merge, MergeResult
-from .planner import Operation, Planner, Analysis
 from ocsf.repository import (
-    RepoPaths,
-    ObjectDefn,
+    AnyDefinition,
+    DefinitionFile,
     EventDefn,
+    ObjectDefn,
+    RepoPath,
+    RepoPaths,
+    Repository,
+    as_path,
     extension,
     extensionless,
-    DefinitionFile,
-    AnyDefinition,
-    Repository,
-    RepoPath,
-    as_path,
 )
+
+from ..merge import MergeResult, merge
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 
 def _find_base(repo: Repository, subject: str, relative_to: RepoPath) -> RepoPath | None:

--- a/src/ocsf/compile/planners/extension.py
+++ b/src/ocsf/compile/planners/extension.py
@@ -2,23 +2,24 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Optional
 
-from ..protoschema import ProtoSchema
-from ..options import CompilationOptions
-from ..merge import merge, MergeResult
-from .planner import Operation, Planner, Analysis
 from ocsf.repository import (
-    DefinitionFile,
-    extension,
-    extensionless,
     AnyDefinition,
-    as_path,
+    AttrDefn,
+    DefinitionFile,
+    DefnWithAttrs,
     DefnWithExtn,
+    ExtensionDefn,
     RepoPaths,
     SpecialFiles,
-    ExtensionDefn,
-    DefnWithAttrs,
-    AttrDefn,
+    as_path,
+    extension,
+    extensionless,
 )
+
+from ..merge import MergeResult, merge
+from ..options import CompilationOptions
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 
 class ExtensionPlanner(Planner):

--- a/src/ocsf/compile/planners/include.py
+++ b/src/ocsf/compile/planners/include.py
@@ -2,21 +2,21 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Optional
 
-from ..protoschema import ProtoSchema
-from ..merge import merge, MergeResult, FieldList
-from .planner import Operation, Planner, Analysis
-
 from ocsf.repository import (
-    DefinitionFile,
-    DefnWithInclude,
-    DefnWithAttrs,
-    Repository,
     AnyDefinition,
+    DefinitionFile,
+    DefnWithAttrs,
+    DefnWithInclude,
     RepoPath,
+    Repository,
+    as_path,
     extension,
     extensionless,
-    as_path,
 )
+
+from ..merge import FieldList, MergeResult, merge
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/ocsf/compile/planners/object_type.py
+++ b/src/ocsf/compile/planners/object_type.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from ..protoschema import ProtoSchema
+from ocsf.repository import AnyDefinition, AttrDefn, DefinitionFile, DefnWithAttrs, EventDefn, ObjectDefn
+
 from ..merge import MergeResult
 from ..options import CompilationOptions
-
-from .planner import Operation, Planner, Analysis
-from ocsf.repository import DefinitionFile, EventDefn, ObjectDefn, AttrDefn, DefnWithAttrs, AnyDefinition
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 
 class _Types:

--- a/src/ocsf/compile/planners/observable.py
+++ b/src/ocsf/compile/planners/observable.py
@@ -22,24 +22,24 @@ across objects and events.
 from dataclasses import dataclass
 from typing import Optional
 
-from ..protoschema import ProtoSchema
-from ..merge import MergeResult
-from ..options import CompilationOptions
-
-from .planner import Operation, Planner, Analysis
 from ocsf.repository import (
-    DefinitionFile,
-    AttrDefn,
-    ObjectDefn,
-    EventDefn,
-    TypeDefn,
-    EnumMemberDefn,
-    DefnWithAttrs,
     AnyDefinition,
-    SpecialFiles,
+    AttrDefn,
+    DefinitionFile,
+    DefnWithAttrs,
     DictionaryDefn,
     DictionaryTypesDefn,
+    EnumMemberDefn,
+    EventDefn,
+    ObjectDefn,
+    SpecialFiles,
+    TypeDefn,
 )
+
+from ..merge import MergeResult
+from ..options import CompilationOptions
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 # TODO build observable object's type_id enum
 
@@ -203,7 +203,10 @@ class BuildObservableTypeOp(Operation):
                         if enum_id not in enum:  # Don't overwrite enum values defined in dictionary.json
                             enum[enum_id] = EnumMemberDefn(
                                 caption=f"{data.caption} {label}: {k}",
-                                description=f'Observable by {label}-Specific Attribute.<br>{label}-specific attribute "{k}" for the {data.caption} {label}.',
+                                description=(
+                                    f"Observable by {label}-Specific Attribute.<br>{label}-specific "
+                                    f'attribute "{k}" for the {data.caption} {label}.'
+                                ),
                             )
                             results.append(("attributes", "type_id", "enum", enum_id))
 

--- a/src/ocsf/compile/planners/planner.py
+++ b/src/ocsf/compile/planners/planner.py
@@ -1,12 +1,12 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional
 
-from ocsf.repository import DefinitionFile, RepoPath, AnyDefinition
+from ocsf.repository import AnyDefinition, DefinitionFile, RepoPath
 
-from ..protoschema import ProtoSchema
-from ..options import CompilationOptions
 from ..merge import MergeResult
+from ..options import CompilationOptions
+from ..protoschema import ProtoSchema
 
 
 @dataclass(eq=True, frozen=True)
@@ -14,8 +14,8 @@ class Operation(ABC):
     target: RepoPath
     prerequisite: Optional[RepoPath] = None
 
-    def apply(self, schema: ProtoSchema) -> MergeResult:
-        raise NotImplementedError()
+    @abstractmethod
+    def apply(self, schema: ProtoSchema) -> MergeResult: ...
 
 
 Analysis = Operation | list[Operation] | None
@@ -26,5 +26,5 @@ class Planner(ABC):
         self._schema = schema
         self._options = options
 
-    def analyze(self, input: DefinitionFile[AnyDefinition]) -> Analysis:
-        raise NotImplementedError()
+    @abstractmethod
+    def analyze(self, input: DefinitionFile[AnyDefinition]) -> Analysis: ...

--- a/src/ocsf/compile/planners/profile.py
+++ b/src/ocsf/compile/planners/profile.py
@@ -8,21 +8,22 @@ Profiles are defined in separate files and add attributes to objects and events.
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from ..protoschema import ProtoSchema
-from ..options import CompilationOptions
-from ..merge import MergeResult
-from .planner import Operation, Planner, Analysis
 from ocsf.repository import (
+    AnyDefinition,
+    AttrDefn,
     DefinitionFile,
-    ProfileDefn,
-    ObjectDefn,
     EventDefn,
+    ObjectDefn,
+    ProfileDefn,
+    RepoPaths,
     as_path,
     extension,
-    RepoPaths,
-    AttrDefn,
-    AnyDefinition,
 )
+
+from ..merge import MergeResult
+from ..options import CompilationOptions
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/ocsf/compile/planners/set_category.py
+++ b/src/ocsf/compile/planners/set_category.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from .planner import Operation, Planner, Analysis
+from ocsf.repository import AnyDefinition, CategoriesDefn, DefinitionFile, EventDefn, RepoPaths, SpecialFiles
+
 from ..merge import MergeResult
 from ..protoschema import ProtoSchema
-
-from ocsf.repository import DefinitionFile, EventDefn, SpecialFiles, RepoPaths, CategoriesDefn, AnyDefinition
+from .planner import Analysis, Operation, Planner
 
 
 @dataclass(eq=True, frozen=True)

--- a/src/ocsf/compile/planners/uid.py
+++ b/src/ocsf/compile/planners/uid.py
@@ -1,21 +1,22 @@
 from dataclasses import dataclass
 
-from ..protoschema import ProtoSchema
-from ..merge import MergeResult, merge
-from .planner import Operation, Planner, Analysis
 from ocsf.repository import (
-    DefinitionFile,
-    CategoryDefn,
-    EnumMemberDefn,
+    AnyDefinition,
+    AttrDefn,
     CategoriesDefn,
+    CategoryDefn,
+    DefinitionFile,
+    EnumMemberDefn,
     EventDefn,
+    ExtensionDefn,
+    RepoPaths,
     SpecialFiles,
     as_path,
-    RepoPaths,
-    ExtensionDefn,
-    AttrDefn,
-    AnyDefinition,
 )
+
+from ..merge import MergeResult, merge
+from ..protoschema import ProtoSchema
+from .planner import Analysis, Operation, Planner
 
 
 def _find_extn_path(schema: ProtoSchema, target: str) -> str | None:

--- a/src/ocsf/compile/planners/uid_names.py
+++ b/src/ocsf/compile/planners/uid_names.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 
-from ocsf.repository import DefinitionFile, EventDefn, AttrDefn, AnyDefinition
+from ocsf.repository import AnyDefinition, AttrDefn, DefinitionFile, EventDefn
+
 from ..merge import MergeResult
 from ..protoschema import ProtoSchema
-from .planner import Operation, Planner, Analysis
+from .planner import Analysis, Operation, Planner
 
 # prepend category_name and class_name caption
 

--- a/src/ocsf/compile/protoschema.py
+++ b/src/ocsf/compile/protoschema.py
@@ -1,33 +1,32 @@
-import dacite
-
 from copy import deepcopy
 from dataclasses import asdict
 from os.path import basename
 from pathlib import PurePath
-from typing import Any, cast, TypeVar
+from typing import Any, TypeVar, cast
 
-from ocsf.schema import OcsfSchema, OcsfObject, OcsfEvent, OcsfType, OcsfProfile, OcsfExtension, OcsfCategory
+import dacite
+
 from ocsf.repository import (
-    Repository,
-    ObjectDefn,
-    EventDefn,
-    SpecialFiles,
-    TypeDefn,
-    ExtensionDefn,
-    ProfileDefn,
-    DictionaryDefn,
-    CategoryDefn,
-    CategoriesDefn,
     AnyDefinition,
-    VersionDefn,
-    DefinitionFile,
+    CategoriesDefn,
+    CategoryDefn,
     DefinitionData,
+    DefinitionFile,
+    DictionaryDefn,
+    EventDefn,
+    ExtensionDefn,
+    ObjectDefn,
+    ProfileDefn,
     RepoPath,
     RepoPaths,
+    Repository,
+    SpecialFiles,
+    TypeDefn,
+    VersionDefn,
     as_path,
     extension,
 )
-
+from ocsf.schema import OcsfCategory, OcsfEvent, OcsfExtension, OcsfObject, OcsfProfile, OcsfSchema, OcsfType
 
 DefnT = TypeVar("DefnT", bound=DefinitionData)
 

--- a/src/ocsf/repository/__init__.py
+++ b/src/ocsf/repository/__init__.py
@@ -26,23 +26,23 @@ from .definitions import (
     VersionDefn,
 )
 from .helpers import (
-    RepoPaths,
     REPO_PATHS,
-    SpecialFiles,
     SPECIAL_FILES,
-    RepoPath,
     Pathlike,
-    sanitize_path,
+    RepoPath,
+    RepoPaths,
+    SpecialFiles,
     as_path,
-    short_name,
-    extension,
-    extensionless,
     category,
     categoryless,
+    extension,
+    extensionless,
     path_defn_t,
+    sanitize_path,
+    short_name,
 )
-from .repository import Repository, DefinitionFile
-from .reader import read_repo, add_extensions, add_extension
+from .reader import add_extension, add_extensions, read_repo
+from .repository import DefinitionFile, Repository
 
 __all__ = [
     "AnyDefinition",

--- a/src/ocsf/repository/definitions.py
+++ b/src/ocsf/repository/definitions.py
@@ -1,14 +1,12 @@
 """A collection of data classes representing the metaschema of the OCSF."""
 
-from abc import ABC
 from dataclasses import dataclass
 from typing import Any, Optional, TypeVar
-
 
 IncludeTarget = str | list[str]
 
 
-class DefinitionPart(ABC): ...
+class DefinitionPart: ...
 
 
 class DefinitionData(DefinitionPart): ...

--- a/src/ocsf/repository/helpers.py
+++ b/src/ocsf/repository/helpers.py
@@ -4,15 +4,15 @@ from enum import StrEnum
 from pathlib import PurePath
 
 from .definitions import (
-    ObjectDefn,
-    EventDefn,
-    IncludeDefn,
-    ProfileDefn,
-    DictionaryDefn,
-    CategoriesDefn,
-    VersionDefn,
-    ExtensionDefn,
     AnyDefinition,
+    CategoriesDefn,
+    DictionaryDefn,
+    EventDefn,
+    ExtensionDefn,
+    IncludeDefn,
+    ObjectDefn,
+    ProfileDefn,
+    VersionDefn,
 )
 
 Pathlike = PurePath | str

--- a/src/ocsf/repository/reader.py
+++ b/src/ocsf/repository/reader.py
@@ -1,16 +1,16 @@
 """Read schema definition files from a directory into a Repository."""
 
 import json
-import dacite
-
 from pathlib import Path
 from typing import Callable
 
-from .repository import Repository, DefinitionFile
-from .definitions import AnyDefinition
-from .helpers import REPO_PATHS, RepoPaths, Pathlike, sanitize_path, path_defn_t
+import dacite
 
 from ocsf.schema import keys_to_names
+
+from .definitions import AnyDefinition
+from .helpers import REPO_PATHS, Pathlike, RepoPaths, path_defn_t, sanitize_path
+from .repository import DefinitionFile, Repository
 
 
 def _to_defn(path: Pathlike, raw_data: str, preserve_raw_data: bool) -> DefinitionFile[AnyDefinition]:
@@ -26,8 +26,8 @@ def _to_defn(path: Pathlike, raw_data: str, preserve_raw_data: bool) -> Definiti
     data = json.loads(raw_data)
     try:
         defn.data = dacite.from_dict(kind, keys_to_names(data))
-    except dacite.DaciteError as e:
-        raise Exception(f"Failed to parse {path}: {e}")
+    except dacite.DaciteError as de:
+        raise Exception(f"Failed to parse {path}") from de
 
     return defn
 

--- a/src/ocsf/repository/repository.py
+++ b/src/ocsf/repository/repository.py
@@ -9,13 +9,13 @@ that path – and, optionally, the raw data from the file as a `str`.
 
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Optional, Iterable, TypeVar, Generic, cast
+from typing import Generic, Optional, TypeVar, cast
 
+from .definitions import AnyDefinition, DefinitionData, ProfileDefn
 from .helpers import RepoPath, RepoPaths, path_defn_t
-from .definitions import AnyDefinition, ProfileDefn, DefinitionData
-
 
 DefnT = TypeVar("DefnT", bound=DefinitionData)
 
@@ -115,6 +115,6 @@ class Repository:
         try:
             assert isinstance(val.data, kind)
             assert path_defn_t(path) == kind
-        except AssertionError:
-            raise TypeError(f"Expected {kind} at {path}, got {type(val.data)}")
+        except AssertionError as ae:
+            raise TypeError(f"Expected {kind} at {path}, got {type(val.data)}") from ae
         return cast(DefinitionFile[DefnT], val)

--- a/src/ocsf/schema/__init__.py
+++ b/src/ocsf/schema/__init__.py
@@ -1,7 +1,19 @@
+from .json import (
+    SchemaOptions,
+    from_dict,
+    from_file,
+    from_json,
+    keys_to_names,
+    names_to_keys,
+    resolve_object_types,
+    to_dict,
+    to_file,
+    to_json,
+)
 from .model import (
     OcsfAttr,
-    OcsfDeprecationInfo,
     OcsfCategory,
+    OcsfDeprecationInfo,
     OcsfElementType,
     OcsfEnumMember,
     OcsfEvent,
@@ -14,18 +26,6 @@ from .model import (
     OcsfType,
     OcsfVersion,
     WithAttributes,
-)
-from .json import (
-    SchemaOptions,
-    from_dict,
-    from_file,
-    from_json,
-    keys_to_names,
-    names_to_keys,
-    resolve_object_types,
-    to_dict,
-    to_file,
-    to_json,
 )
 
 __all__ = [

--- a/src/ocsf/schema/__main__.py
+++ b/src/ocsf/schema/__main__.py
@@ -10,8 +10,8 @@ Example:
 
 from argparse import ArgumentParser
 
-from ocsf.util import get_schema
 from ocsf.schema import to_json
+from ocsf.util import get_schema
 
 
 def main():
@@ -19,7 +19,10 @@ def main():
 
     parser.add_argument(
         "schema",
-        help="Path to a schema JSON file, a version identifier (to retrieve from schema.ocsf.io), or a path to an OCSF repository.",
+        help=(
+            "Path to a schema JSON file, a version identifier (to retrieve from schema.ocsf.io), "
+            "or a path to an OCSF repository."
+        ),
     )
     args = parser.parse_args()
 

--- a/src/ocsf/schema/json.py
+++ b/src/ocsf/schema/json.py
@@ -9,10 +9,10 @@ schema = from_file("schema.json")
 """
 
 import json
-import dacite
-
 from dataclasses import asdict, dataclass
 from typing import Any, cast
+
+import dacite
 
 from .model import OcsfSchema, WithAttributes
 
@@ -92,19 +92,21 @@ def resolve_object_types(things: dict[str, WithAttributes] | OcsfSchema | WithAt
         resolve_object_types(thing)
 
 
-def from_dict(data: dict[str, Any], options: SchemaOptions = SchemaOptions()) -> OcsfSchema:
+def from_dict(data: dict[str, Any], options: SchemaOptions | None = None) -> OcsfSchema:
     """Parse an OCSF schema from a dictionary."""
+    _options = SchemaOptions() if options is None else options
     schema = dacite.from_dict(OcsfSchema, keys_to_names(data))
 
-    if options.resolve_object_types:
+    if _options.resolve_object_types:
         resolve_object_types(schema)
 
     return schema
 
 
-def from_json(data: str, options: SchemaOptions = SchemaOptions()) -> OcsfSchema:
+def from_json(data: str, options: SchemaOptions | None = None) -> OcsfSchema:
     """Parse an OCSF schema from a JSON string."""
-    return from_dict(json.loads(data), options)
+    _options = SchemaOptions() if options is None else options
+    return from_dict(json.loads(data), _options)
 
 
 def to_dict(schema: OcsfSchema) -> dict[str, Any]:
@@ -117,9 +119,9 @@ def to_json(schema: OcsfSchema) -> str:
     return json.dumps(to_dict(schema))
 
 
-def from_file(path: str, options: SchemaOptions = SchemaOptions()) -> OcsfSchema:
+def from_file(path: str, options: SchemaOptions | None = None) -> OcsfSchema:
     """Parse an OCSF schema from a JSON file."""
-    with open(path, "r") as f:
+    with open(path) as f:
         return from_json(f.read())
 
 

--- a/src/ocsf/schema/model.py
+++ b/src/ocsf/schema/model.py
@@ -1,12 +1,11 @@
 """This module contains the dataclasses that represent the OCSF schema."""
 
-from abc import ABC
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any, Optional, TypeVar
 
 
-class OcsfModel(ABC): ...
+class OcsfModel: ...
 
 
 # TODO: is this used?

--- a/src/ocsf/util/get_schema.py
+++ b/src/ocsf/util/get_schema.py
@@ -1,15 +1,16 @@
 import os
 from typing import Optional
+
 from ocsf.api import OcsfApiClient
-from ocsf.schema import OcsfSchema, from_file
-from ocsf.repository import read_repo
 from ocsf.compile import Compilation, CompilationOptions
+from ocsf.repository import read_repo
+from ocsf.schema import OcsfSchema, from_file
 
 
 def get_schema(
-    versionOrFile: Optional[str] = None,
+    version_or_file: Optional[str] = None,
     client: Optional[OcsfApiClient] = None,
-    compile_options: CompilationOptions = CompilationOptions(),
+    compile_options: CompilationOptions | None = None,
 ) -> OcsfSchema:
     """Fetch a schema from a filename or version.
 
@@ -22,7 +23,7 @@ def get_schema(
         ```
 
     Args:
-        versionOrFile: The name of an OCSF schema file or a valid semantic version number.
+        version_or_file: The name of an OCSF schema file or a valid semantic version number.
 
     Returns:
         The requested OcsfSchema.
@@ -31,16 +32,17 @@ def get_schema(
         ValueError: If the version requested is not found on the server or
             if the requested version is invalid.
     """
-    if versionOrFile is not None:
-        if os.path.isdir(versionOrFile):
-            repo = read_repo(versionOrFile)
-            compilation = Compilation(repo, options=compile_options)
+    _compile_options = CompilationOptions() if compile_options is None else compile_options
+    if version_or_file is not None:
+        if os.path.isdir(version_or_file):
+            repo = read_repo(version_or_file)
+            compilation = Compilation(repo, options=_compile_options)
             return compilation.build()
 
-        elif os.path.isfile(versionOrFile):
-            return from_file(versionOrFile)
+        elif os.path.isfile(version_or_file):
+            return from_file(version_or_file)
 
     if client is None:
         client = OcsfApiClient()
 
-    return client.get_schema(versionOrFile)
+    return client.get_schema(version_or_file)

--- a/src/ocsf/validate/compatibility/__init__.py
+++ b/src/ocsf/validate/compatibility/__init__.py
@@ -1,13 +1,13 @@
-from .changed_type import NoChangedTypesRule, ChangedTypeFinding
-from .increased_requirement import NoIncreasedRequirementsRule, IncreasedRequirementFinding
+from .changed_type import ChangedTypeFinding, NoChangedTypesRule
+from .increased_requirement import IncreasedRequirementFinding, NoIncreasedRequirementsRule
 from .removed_records import (
     NoRemovedRecordsRule,
-    RemovedObjectFinding,
-    RemovedEventFinding,
     RemovedAttrFinding,
     RemovedEnumMemberFinding,
+    RemovedEventFinding,
+    RemovedObjectFinding,
 )
-from .removed_uids import NoChangedClassUidsRule, ChangedClassUidFinding
+from .removed_uids import ChangedClassUidFinding, NoChangedClassUidsRule
 from .validator import CompatibilityValidator
 
 __all__ = [

--- a/src/ocsf/validate/compatibility/__main__.py
+++ b/src/ocsf/validate/compatibility/__main__.py
@@ -59,25 +59,25 @@ Validate a working copy of the OCSF schema repository against the latest stable 
 
 """
 
-import tomllib
 from argparse import ArgumentParser
 from typing import cast
 from urllib.error import URLError
+
+import tomllib
 from termcolor import colored
 
 from ocsf.api import OcsfApiClient
+from ocsf.compare import ChangedSchema, compare
 from ocsf.util import get_schema
 from ocsf.validate.framework import (
-    Severity,
     ColoringValidationFormatter,
+    Severity,
     ValidationFormatter,
-    validate_severities,
     count_severity,
+    validate_severities,
 )
-from ocsf.compare import compare, ChangedSchema
 
 from .validator import CompatibilityValidator
-
 
 # Various modules use logging. Configure as you see fit.
 # import logging

--- a/src/ocsf/validate/compatibility/added_required_attrs.py
+++ b/src/ocsf/validate/compatibility/added_required_attrs.py
@@ -1,9 +1,10 @@
 """A validation rule to identify changed attribute types."""
 
 from dataclasses import dataclass
-from ocsf.compare import ChangedSchema, ChangedEvent, ChangedObject, Addition
+
+from ocsf.compare import Addition, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.schema import OcsfElementType
-from ocsf.validate.framework import Rule, Finding, RuleMetadata
+from ocsf.validate.framework import Finding, Rule, RuleMetadata
 from ocsf.validate.framework.validator import Severity
 
 

--- a/src/ocsf/validate/compatibility/changed_type.py
+++ b/src/ocsf/validate/compatibility/changed_type.py
@@ -1,9 +1,10 @@
 """A validation rule to identify changed attribute types."""
 
 from dataclasses import dataclass
-from ocsf.compare import Difference, ChangedSchema, Change, ChangedEvent, ChangedObject, ChangedAttr
-from ocsf.schema import OcsfElementType, OcsfAttr
-from ocsf.validate.framework import Rule, Finding, RuleMetadata
+
+from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema, Difference
+from ocsf.schema import OcsfAttr, OcsfElementType
+from ocsf.validate.framework import Finding, Rule, RuleMetadata
 
 
 @dataclass

--- a/src/ocsf/validate/compatibility/increased_requirement.py
+++ b/src/ocsf/validate/compatibility/increased_requirement.py
@@ -1,9 +1,10 @@
 """A validation rule to identify changed attribute types."""
 
 from dataclasses import dataclass
-from ocsf.compare import ChangedSchema, Change, ChangedEvent, ChangedObject, ChangedAttr
+
+from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.schema import OcsfElementType
-from ocsf.validate.framework import Rule, Finding, RuleMetadata
+from ocsf.validate.framework import Finding, Rule, RuleMetadata
 
 
 @dataclass

--- a/src/ocsf/validate/compatibility/removed_records.py
+++ b/src/ocsf/validate/compatibility/removed_records.py
@@ -9,11 +9,11 @@ caption or class_uid is added to the same set.
 """
 
 from dataclasses import dataclass
-from typing import Optional, Literal
+from typing import Literal, Optional
 
+from ocsf.compare import Addition, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema, Removal
 from ocsf.schema import OcsfElementType
-from ocsf.compare import ChangedSchema, Removal, Addition, ChangedEvent, ChangedObject, ChangedAttr
-from ocsf.validate.framework import Rule, Finding, RuleMetadata
+from ocsf.validate.framework import Finding, Rule, RuleMetadata
 
 
 def _path(
@@ -76,7 +76,9 @@ class RenamedRecordFinding(Finding):
         return self.root
 
     def message(self) -> str:
-        return f"{_path(self._root(), self.before, self.path)} ({self.caption}) appears to have been renamed to {_path(self._root(), self.after, self.path)}"
+        before_path = _path(self._root(), self.before, self.path)
+        after_path = _path(self._root(), self.after, self.path)
+        return f"{before_path} ({self.caption}) appears to have been renamed to {after_path}"
 
 
 class RenamedEventFinding(RenamedRecordFinding): ...

--- a/src/ocsf/validate/compatibility/removed_uids.py
+++ b/src/ocsf/validate/compatibility/removed_uids.py
@@ -1,8 +1,9 @@
 """A validation rule to identify changed class UIDs."""
 
 from dataclasses import dataclass
-from ocsf.compare import ChangedSchema, NoChange, ChangedEvent, ChangedAttr, Removal, Addition
-from ocsf.validate.framework import Rule, Finding, RuleMetadata
+
+from ocsf.compare import Addition, ChangedAttr, ChangedEvent, ChangedSchema, NoChange, Removal
+from ocsf.validate.framework import Finding, Rule, RuleMetadata
 
 
 @dataclass

--- a/src/ocsf/validate/compatibility/validator.py
+++ b/src/ocsf/validate/compatibility/validator.py
@@ -3,11 +3,11 @@
 from ocsf.compare import ChangedSchema
 from ocsf.validate.framework import Rule, Validator
 
+from .added_required_attrs import NoAddedRequiredAttrsRule
 from .changed_type import NoChangedTypesRule
 from .increased_requirement import NoIncreasedRequirementsRule
 from .removed_records import NoRemovedRecordsRule
 from .removed_uids import NoChangedClassUidsRule
-from .added_required_attrs import NoAddedRequiredAttrsRule
 
 
 class CompatibilityValidator(Validator[ChangedSchema]):

--- a/src/ocsf/validate/framework/__init__.py
+++ b/src/ocsf/validate/framework/__init__.py
@@ -1,7 +1,6 @@
-from .validator import Rule, Validator, Finding, RuleMetadata, Severity, validate_severities
-from .summarize import summarize_findings, count_severity
-from .formatting import ValidationFormatter, ColoringValidationFormatter
-
+from .formatting import ColoringValidationFormatter, ValidationFormatter
+from .summarize import count_severity, summarize_findings
+from .validator import Finding, Rule, RuleMetadata, Severity, Validator, validate_severities
 
 __all__ = [
     "Finding",

--- a/src/ocsf/validate/framework/formatting.py
+++ b/src/ocsf/validate/framework/formatting.py
@@ -1,9 +1,11 @@
 from dataclasses import dataclass
 from textwrap import wrap
 from typing import Literal
+
 from termcolor import colored
-from .validator import Finding, ValidationFindings, Context, Severity
+
 from .summarize import summarize_findings
+from .validator import Context, Finding, Severity, ValidationFindings
 
 
 class ValidationFormatter:

--- a/src/ocsf/validate/framework/summarize.py
+++ b/src/ocsf/validate/framework/summarize.py
@@ -1,4 +1,4 @@
-from .validator import Severity, ValidationFindings, Context
+from .validator import Context, Severity, ValidationFindings
 
 
 def count_severity(findings: ValidationFindings[Context], severity: Severity) -> int:

--- a/src/ocsf/validate/framework/validator.py
+++ b/src/ocsf/validate/framework/validator.py
@@ -21,11 +21,10 @@ merged.
 """
 
 import logging
-
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TypeVar, Generic, Optional
+from typing import Generic, Optional, TypeVar
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/ocsf/api/test_client.py
+++ b/tests/ocsf/api/test_client.py
@@ -1,9 +1,8 @@
 import pytest
+from semver import Version
 
 from ocsf.api import OcsfApiClient, SchemaVersion, SchemaVersions
-from ocsf.schema.model import OcsfSchema, OcsfProfile, OcsfExtension
-
-from semver import Version
+from ocsf.schema.model import OcsfExtension, OcsfProfile, OcsfSchema
 
 
 def setup() -> OcsfApiClient:

--- a/tests/ocsf/compare/test_compare.py
+++ b/tests/ocsf/compare/test_compare.py
@@ -1,15 +1,15 @@
 # pyright: reportPrivateUsage = false
-from typing import Optional, Any
+from typing import Any, Optional
 
 from ocsf.compare import (
-    compare,
-    compare_dict,
+    Addition,
     Change,
-    NoChange,
     ChangedAttr,
     ChangedEnumMember,
+    NoChange,
     Removal,
-    Addition,
+    compare,
+    compare_dict,
 )
 from ocsf.schema import OcsfAttr, OcsfEnumMember
 

--- a/tests/ocsf/compare/test_factory.py
+++ b/tests/ocsf/compare/test_factory.py
@@ -1,24 +1,24 @@
-from ocsf.schema import (
-    OcsfSchema,
-    OcsfEvent,
-    OcsfObject,
-    OcsfAttr,
-    OcsfDeprecationInfo,
-    OcsfType,
-    OcsfVersion,
-    OcsfEnumMember,
-)
+from ocsf.compare.factory import create_diff
 from ocsf.compare.model import (
-    ChangedSchema,
-    ChangedEvent,
-    ChangedObject,
     ChangedAttr,
     ChangedDeprecationInfo,
+    ChangedEnumMember,
+    ChangedEvent,
+    ChangedObject,
+    ChangedSchema,
     ChangedType,
     ChangedVersion,
-    ChangedEnumMember,
 )
-from ocsf.compare.factory import create_diff
+from ocsf.schema import (
+    OcsfAttr,
+    OcsfDeprecationInfo,
+    OcsfEnumMember,
+    OcsfEvent,
+    OcsfObject,
+    OcsfSchema,
+    OcsfType,
+    OcsfVersion,
+)
 
 
 def test_create_diff():

--- a/tests/ocsf/compile/planners/test_dictionary.py
+++ b/tests/ocsf/compile/planners/test_dictionary.py
@@ -1,16 +1,16 @@
+from ocsf.compile.options import CompilationOptions
+from ocsf.compile.planners.dictionary import DictionaryOp, DictionaryPlanner
+from ocsf.compile.protoschema import ProtoSchema
 from ocsf.repository import (
-    Repository,
+    AttrDefn,
+    CategoriesDefn,
     DefinitionFile,
     DictionaryDefn,
-    ObjectDefn,
-    AttrDefn,
-    ProfileDefn,
     IncludeDefn,
-    CategoriesDefn,
+    ObjectDefn,
+    ProfileDefn,
+    Repository,
 )
-from ocsf.compile.protoschema import ProtoSchema
-from ocsf.compile.options import CompilationOptions
-from ocsf.compile.planners.dictionary import DictionaryPlanner, DictionaryOp
 
 
 def get_repo():

--- a/tests/ocsf/compile/planners/test_extends.py
+++ b/tests/ocsf/compile/planners/test_extends.py
@@ -1,8 +1,11 @@
-from ocsf.repository import Repository, DefinitionFile, AttrDefn, EventDefn
-from ocsf.compile.protoschema import ProtoSchema
 from ocsf.compile.options import CompilationOptions
-from ocsf.compile.planners.extends import ExtendsPlanner, ExtendsOp
-from ocsf.compile.planners.extends import _find_base  # type: ignore
+from ocsf.compile.planners.extends import (
+    ExtendsOp,
+    ExtendsPlanner,
+    _find_base,  # type: ignore
+)
+from ocsf.compile.protoschema import ProtoSchema
+from ocsf.repository import AttrDefn, DefinitionFile, EventDefn, Repository
 
 
 def get_repo():

--- a/tests/ocsf/compile/planners/test_observable.py
+++ b/tests/ocsf/compile/planners/test_observable.py
@@ -1,16 +1,19 @@
+from ocsf.compile import CompilationOptions
+from ocsf.compile.planners.observable import (
+    MarkObservablesOp,
+    MarkObservablesPlanner,
+    _Registry,  # type: ignore
+)
+from ocsf.compile.protoschema import ProtoSchema
 from ocsf.repository import (
-    Repository,
+    AttrDefn,
+    DefinitionFile,
     DictionaryDefn,
     DictionaryTypesDefn,
-    DefinitionFile,
     ObjectDefn,
+    Repository,
     TypeDefn,
-    AttrDefn,
 )
-from ocsf.compile import CompilationOptions
-from ocsf.compile.protoschema import ProtoSchema
-from ocsf.compile.planners.observable import MarkObservablesPlanner, MarkObservablesOp
-from ocsf.compile.planners.observable import _Registry  # type: ignore
 
 
 def get_ps():

--- a/tests/ocsf/compile/planners/test_profile.py
+++ b/tests/ocsf/compile/planners/test_profile.py
@@ -1,5 +1,3 @@
-from ocsf.repository import Repository, DefinitionFile, ProfileDefn, AttrDefn, ExtensionDefn
-from ocsf.compile.protoschema import ProtoSchema
 from ocsf.compile.planners.profile import (
     # ExcludeProfileAttrsOp,
     # MarkProfileOp,
@@ -7,6 +5,8 @@ from ocsf.compile.planners.profile import (
     # ExcludeProfileAttrsPlanner,
     _find_profile,  # type: ignore
 )
+from ocsf.compile.protoschema import ProtoSchema
+from ocsf.repository import AttrDefn, DefinitionFile, ExtensionDefn, ProfileDefn, Repository
 
 
 def get_repo():

--- a/tests/ocsf/compile/planners/test_uid.py
+++ b/tests/ocsf/compile/planners/test_uid.py
@@ -1,16 +1,16 @@
+from ocsf.compile.options import CompilationOptions
+from ocsf.compile.planners.uid import UidOp, UidPlanner
+from ocsf.compile.protoschema import ProtoSchema
 from ocsf.repository import (
-    Repository,
-    DefinitionFile,
     AttrDefn,
-    EventDefn,
     CategoriesDefn,
     CategoryDefn,
-    ExtensionDefn,
+    DefinitionFile,
     EnumMemberDefn,
+    EventDefn,
+    ExtensionDefn,
+    Repository,
 )
-from ocsf.compile.protoschema import ProtoSchema
-from ocsf.compile.options import CompilationOptions
-from ocsf.compile.planners.uid import UidPlanner, UidOp
 
 
 def get_repo():

--- a/tests/ocsf/compile/test_can_update.py
+++ b/tests/ocsf/compile/test_can_update.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from ocsf.compile.merge import MergeOptions, _can_update  # type: ignore
 from ocsf.repository import DefinitionPart
-from ocsf.compile.merge import _can_update, MergeOptions  # type: ignore
 
 
 @dataclass

--- a/tests/ocsf/compile/test_compiler.py
+++ b/tests/ocsf/compile/test_compiler.py
@@ -1,14 +1,22 @@
 import os
 
-from ocsf.repository import read_repo, Repository
-from ocsf.compile.planners.planner import Operation
 from ocsf.compile.compiler import Compilation, CompilationOperations
+from ocsf.compile.merge import MergeResult
+from ocsf.compile.planners.planner import Operation
+from ocsf.compile.protoschema import ProtoSchema
+from ocsf.repository import Repository, read_repo
 
 
-class OpTest1(Operation): ...
+class OpTest1(Operation):
+    def apply(self, schema: ProtoSchema) -> MergeResult:
+        result: MergeResult = []
+        return result
 
 
-class OpTest2(Operation): ...
+class OpTest2(Operation):
+    def apply(self, schema: ProtoSchema) -> MergeResult:
+        result: MergeResult = []
+        return result
 
 
 def get_compiler():

--- a/tests/ocsf/compile/test_merge.py
+++ b/tests/ocsf/compile/test_merge.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from ocsf.compile.merge import MergeOptions, merge
 from ocsf.repository import DefinitionPart
-from ocsf.compile.merge import merge, MergeOptions
 
 
 def test_options_init():

--- a/tests/ocsf/compile/test_versus.py
+++ b/tests/ocsf/compile/test_versus.py
@@ -1,25 +1,25 @@
 import os
 from typing import Any
 
-from ocsf.util import get_schema
 from ocsf.compare import (
-    compare,
-    ChangedSchema,
-    ChangedCategory,
-    ChangedProfile,
-    ChangedExtension,
-    Change,
-    NoChange,
-    ChangedEvent,
-    ChangedDeprecationInfo,
-    ChangedAttr,
-    ChangedObject,
-    Removal,
     Addition,
+    Change,
+    ChangedAttr,
+    ChangedCategory,
+    ChangedDeprecationInfo,
+    ChangedEvent,
+    ChangedExtension,
+    ChangedObject,
+    ChangedProfile,
+    ChangedSchema,
     Difference,
+    NoChange,
+    Removal,
+    compare,
 )
-from ocsf.repository import read_repo
 from ocsf.compile.compiler import Compilation
+from ocsf.repository import read_repo
+from ocsf.util import get_schema
 
 
 def get_diff():

--- a/tests/ocsf/repository/test_helpers.py
+++ b/tests/ocsf/repository/test_helpers.py
@@ -1,16 +1,16 @@
 import pytest
 
-from ocsf.repository.helpers import path_defn_t, RepoPaths, SpecialFiles, REPO_PATHS, SPECIAL_FILES
 from ocsf.repository.definitions import (
-    ObjectDefn,
-    EventDefn,
-    IncludeDefn,
-    ProfileDefn,
-    DictionaryDefn,
     CategoriesDefn,
-    VersionDefn,
+    DictionaryDefn,
+    EventDefn,
     ExtensionDefn,
+    IncludeDefn,
+    ObjectDefn,
+    ProfileDefn,
+    VersionDefn,
 )
+from ocsf.repository.helpers import REPO_PATHS, SPECIAL_FILES, RepoPaths, SpecialFiles, path_defn_t
 
 
 def test_path_defn_t():

--- a/tests/ocsf/repository/test_repository.py
+++ b/tests/ocsf/repository/test_repository.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ocsf.repository.definitions import DictionaryDefn, ProfileDefn, ObjectDefn, EventDefn, ExtensionDefn
+from ocsf.repository.definitions import DictionaryDefn, EventDefn, ExtensionDefn, ObjectDefn, ProfileDefn
 from ocsf.repository.repository import DefinitionFile, Repository
 
 

--- a/tests/ocsf/schema/test_key_xforms.py
+++ b/tests/ocsf/schema/test_key_xforms.py
@@ -1,4 +1,4 @@
-from ocsf.schema.json import names_to_keys, keys_to_names
+from ocsf.schema.json import keys_to_names, names_to_keys
 
 
 def test_names_to_keys():

--- a/tests/ocsf/schema/test_parsing.py
+++ b/tests/ocsf/schema/test_parsing.py
@@ -1,5 +1,6 @@
 import os
-from ocsf.schema import OcsfEvent, from_json, SchemaOptions
+
+from ocsf.schema import OcsfEvent, SchemaOptions, from_json
 
 LOCATION = os.path.dirname(os.path.abspath(__file__))
 SCHEMA_JSON = os.path.join(LOCATION, "../..", "schema_cache/schema-1.1.0.json")
@@ -23,7 +24,7 @@ JSON_DATA = """{
     }
   },
   "objects": {
-  
+
   },
   "types": {
 
@@ -41,7 +42,7 @@ JSON_DATA = """{
             "description": "Event timestamp"
         }
     }
-  
+
   }
 }"""
 
@@ -57,7 +58,7 @@ def test_decode_str():
 def test_decode_file():
     """Test decoding a JSON file into an OCSF schema."""
     json_str: str | None = None
-    with open(SCHEMA_JSON, "r") as f:
+    with open(SCHEMA_JSON) as f:
         json_str = f.read()
     assert json_str is not None
     schema = from_json(json_str)

--- a/tests/ocsf/util/test_get_schema.py
+++ b/tests/ocsf/util/test_get_schema.py
@@ -1,10 +1,10 @@
 import os
+
 import pytest
 
 from ocsf.api import OcsfApiClient
 from ocsf.schema import OcsfSchema
 from ocsf.util import get_schema
-
 
 LOCATION = os.path.dirname(os.path.abspath(__file__))
 CACHE = os.path.join(LOCATION, "../../..", "schema_cache")

--- a/tests/ocsf/validate/compatibility/test_added_required_attrs.py
+++ b/tests/ocsf/validate/compatibility/test_added_required_attrs.py
@@ -1,7 +1,7 @@
+from ocsf.compare import Addition, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.schema import OcsfAttr, OcsfProfile
-from ocsf.compare import ChangedSchema, ChangedEvent, ChangedObject, Addition
-from ocsf.validate.framework import Severity
 from ocsf.validate.compatibility.added_required_attrs import AddedRequiredAttrFinding, NoAddedRequiredAttrsRule
+from ocsf.validate.framework import Severity
 
 
 def test_added_required_attr_event():

--- a/tests/ocsf/validate/compatibility/test_changed_type.py
+++ b/tests/ocsf/validate/compatibility/test_changed_type.py
@@ -1,4 +1,4 @@
-from ocsf.compare import ChangedSchema, ChangedEvent, ChangedObject, ChangedAttr, Change
+from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.validate.compatibility import ChangedTypeFinding, NoChangedTypesRule
 
 

--- a/tests/ocsf/validate/compatibility/test_increased_requirement.py
+++ b/tests/ocsf/validate/compatibility/test_increased_requirement.py
@@ -1,4 +1,4 @@
-from ocsf.compare import ChangedSchema, ChangedEvent, ChangedObject, ChangedAttr, Change
+from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.validate.compatibility import IncreasedRequirementFinding, NoIncreasedRequirementsRule
 
 

--- a/tests/ocsf/validate/compatibility/test_removed_records.py
+++ b/tests/ocsf/validate/compatibility/test_removed_records.py
@@ -1,15 +1,15 @@
-from ocsf.schema import OcsfEvent, OcsfObject, OcsfAttr, OcsfEnumMember
-from ocsf.compare import ChangedSchema, Addition, Removal, ChangedEvent, ChangedObject, ChangedAttr
+from ocsf.compare import Addition, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema, Removal
+from ocsf.schema import OcsfAttr, OcsfEnumMember, OcsfEvent, OcsfObject
 from ocsf.validate.compatibility.removed_records import (
     NoRemovedRecordsRule,
-    RemovedObjectFinding,
-    RemovedEventFinding,
     RemovedAttrFinding,
     RemovedEnumMemberFinding,
-    RenamedEventFinding,
-    RenamedObjectFinding,
+    RemovedEventFinding,
+    RemovedObjectFinding,
     RenamedAttrFinding,
     RenamedEnumMemberFinding,
+    RenamedEventFinding,
+    RenamedObjectFinding,
 )
 
 

--- a/tests/ocsf/validate/compatibility/test_removed_uids.py
+++ b/tests/ocsf/validate/compatibility/test_removed_uids.py
@@ -1,5 +1,5 @@
+from ocsf.compare import Addition, ChangedAttr, ChangedEvent, ChangedSchema, Removal
 from ocsf.schema import OcsfEnumMember
-from ocsf.compare import ChangedSchema, ChangedEvent, ChangedAttr, Removal, Addition
 from ocsf.validate.compatibility import ChangedClassUidFinding, NoChangedClassUidsRule
 
 

--- a/tests/ocsf/validate/framework/test_summarize.py
+++ b/tests/ocsf/validate/framework/test_summarize.py
@@ -1,5 +1,5 @@
-from ocsf.validate.framework.validator import Severity, Finding, Rule, RuleMetadata, ValidationFindings
 from ocsf.validate.framework.summarize import count_severity, summarize_findings
+from ocsf.validate.framework.validator import Finding, Rule, RuleMetadata, Severity, ValidationFindings
 
 
 class FakeFinding(Finding):

--- a/tests/ocsf/validate/framework/test_validator.py
+++ b/tests/ocsf/validate/framework/test_validator.py
@@ -1,4 +1,4 @@
-from ocsf.validate.framework.validator import Severity, Finding, Rule, RuleMetadata, Validator
+from ocsf.validate.framework.validator import Finding, Rule, RuleMetadata, Severity, Validator
 
 
 class FakeContext: ...


### PR DESCRIPTION
- CI/CD runs ruff format --check
- Added additional configuration for ruff to catch more issues
- Fixed several code smells (mutable default arguments especially)
- Updated ruff version
- Marked poetry.lock in .gitattributes as a generated file (github will hide diffs for files marked as generated)