### PR TITLE
Wiring category events into compilation CLI options and making event …

### DIFF
--- a/src/ocsf/compile/__main__.py
+++ b/src/ocsf/compile/__main__.py
@@ -32,10 +32,11 @@ options:
   --set-observable      Set the observable field on attributes to the corresponding Observable Type ID where applicable
   --no-set-observable   Do not set the observable field on attributes to the corresponding Observable Type ID
                         where applicable
-  --category-classes    Include classes in the category section of the schema output. This duplicates classes in each category without attributes in the
-                        same way as the OCSF Server's category export.
+  --category-classes    Include classes in the category section of the schema output. This duplicates classes in each
+                        category without attributes in the same way as the OCSF Server's category export.
   --no-category-classes
-                        Do not include classes in the category section of the schema output. This is the default behavior.
+                        Do not include classes in the category section of the schema output. This is the default
+                        behavior.
 ```
 
 Examples:
@@ -143,7 +144,10 @@ def main():
         "--no-category-classes",
         dest="category_classes",
         action="store_false",
-        help=("Do not include classes in the category section of the schema output. " "This is the default behavior."),
+        help=(
+            "Do not include classes in the category section of the schema output. "
+            "This is the default behavior."
+        ),
     )
 
     args = parser.parse_args()

--- a/src/ocsf/compile/__main__.py
+++ b/src/ocsf/compile/__main__.py
@@ -32,6 +32,10 @@ options:
   --set-observable      Set the observable field on attributes to the corresponding Observable Type ID where applicable
   --no-set-observable   Do not set the observable field on attributes to the corresponding Observable Type ID
                         where applicable
+  --category-classes    Include classes in the category section of the schema output. This duplicates classes in each category without attributes in the
+                        same way as the OCSF Server's category export.
+  --no-category-classes
+                        Do not include classes in the category section of the schema output. This is the default behavior.
 ```
 
 Examples:
@@ -125,6 +129,25 @@ def main():
         action="store_false",
         help="Do not set the observable field on attributes to the corresponding Observable Type ID where applicable",
     )
+    parser.add_argument(
+        "--category-classes",
+        action="store_true",
+        default=True,
+        help=(
+            "Include classes in the category section of the schema output. This "
+            "duplicates classes in each category without attributes in the same "
+            "way as the OCSF Server's category export."
+        ),
+    )
+    parser.add_argument(
+        "--no-category-classes",
+        dest="category_classes",
+        action="store_false",
+        help=(
+            "Do not include classes in the category section of the schema output. "
+            "This is the default behavior."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -142,6 +165,7 @@ def main():
     options.prefix_extensions = args.prefix_extensions
     options.set_object_types = args.set_object_types
     options.set_observable = args.set_observable
+    options.map_events_to_categories = args.category_classes
 
     repo = read_repo(args.path, preserve_raw_data=False)
 

--- a/src/ocsf/compile/__main__.py
+++ b/src/ocsf/compile/__main__.py
@@ -144,10 +144,7 @@ def main():
         "--no-category-classes",
         dest="category_classes",
         action="store_false",
-        help=(
-            "Do not include classes in the category section of the schema output. "
-            "This is the default behavior."
-        ),
+        help=("Do not include classes in the category section of the schema output. " "This is the default behavior."),
     )
 
     args = parser.parse_args()

--- a/src/ocsf/compile/__main__.py
+++ b/src/ocsf/compile/__main__.py
@@ -143,10 +143,7 @@ def main():
         "--no-category-classes",
         dest="category_classes",
         action="store_false",
-        help=(
-            "Do not include classes in the category section of the schema output. "
-            "This is the default behavior."
-        ),
+        help=("Do not include classes in the category section of the schema output. " "This is the default behavior."),
     )
 
     args = parser.parse_args()

--- a/src/ocsf/compile/compiler.py
+++ b/src/ocsf/compile/compiler.py
@@ -111,7 +111,7 @@ class Compilation:
                 # attribute of records easier. Only performed if
                 # options.set_observable is True.
                 MarkObservablesPlanner(self._proto, _options),
-                # Map events to categories in the categories.json file.
+                # Map events to the `classes` dictionary of each category.
                 MapEventToCategoryPlanner(self._proto, _options),
                 # Copy records that are ONLY defined in extensions to the core
                 # schema so that they are included by ProtoSchema.schema().

--- a/src/ocsf/compile/planners/set_category.py
+++ b/src/ocsf/compile/planners/set_category.py
@@ -21,11 +21,16 @@ class SetCategoryOp(Operation):
             return []
 
         path = PurePath(target.path).parts
+        if path[-1] == SpecialFiles.BASE_EVENT.value:
+            return []
+
         if RepoPaths.EVENTS.value not in path:
             raise ValueError(f"Cannot assign category to non-event: {target.path}")
             return []
 
         category = path[path.index(RepoPaths.EVENTS.value) + 1]
+        if category == "base_event.json":
+            return []
 
         categories = schema[SpecialFiles.CATEGORIES].data
         assert isinstance(categories, CategoriesDefn)

--- a/src/ocsf/repository/helpers.py
+++ b/src/ocsf/repository/helpers.py
@@ -48,7 +48,14 @@ class SpecialFiles(StrEnum):
         return path in [e.value for e in SpecialFiles]
 
 
-SPECIAL_FILES = ("dictionary.json", "categories.json", "version.json", "extension.json", "objects/observable.json")
+SPECIAL_FILES = (
+    "dictionary.json",
+    "categories.json",
+    "version.json",
+    "extension.json",
+    "objects/observable.json",
+    "base_event.json",
+)
 """Tuple containing strings of the values in the SpecialFiles enum."""
 
 

--- a/src/ocsf/repository/helpers.py
+++ b/src/ocsf/repository/helpers.py
@@ -41,6 +41,7 @@ class SpecialFiles(StrEnum):
     VERSION = "version.json"
     EXTENSION = "extension.json"
     OBSERVABLE = "objects/observable.json"
+    BASE_EVENT = "base_event.json"
 
     @staticmethod
     def contains(path: str) -> bool:


### PR DESCRIPTION
The `ocsf.compile` package had the ability to map event classes to categories and store this mapping in the `categories` section of the schema export in a structure similar to the OCSF Server's `api/categories` endpoint.

*But* I forgot to wire that capability into the CLI options when running `ocsf.compile`. Whoops!

This PR fixes that oversight.

It also adds special handling for `base_event` when assigning categories to events in the `classes` section of the schema export. The bug addressed by this was identified in a private extension that decorates `base_event`; it does not appear in OCSF 1.4.