### PR TITLE
Relax type change rules

### DIFF
--- a/src/ocsf/validate/compatibility/__init__.py
+++ b/src/ocsf/validate/compatibility/__init__.py
@@ -1,3 +1,4 @@
+from .context import CompatibilityContext
 from .changed_type import ChangedTypeFinding, NoChangedTypesRule
 from .increased_requirement import IncreasedRequirementFinding, NoIncreasedRequirementsRule
 from .removed_records import (
@@ -8,7 +9,7 @@ from .removed_records import (
     RemovedObjectFinding,
 )
 from .removed_uids import ChangedClassUidFinding, NoChangedClassUidsRule
-from .validator import CompatibilityValidator, CompatibilityContext
+from .validator import CompatibilityValidator
 
 __all__ = [
     "ChangedClassUidFinding",

--- a/src/ocsf/validate/compatibility/__init__.py
+++ b/src/ocsf/validate/compatibility/__init__.py
@@ -8,11 +8,12 @@ from .removed_records import (
     RemovedObjectFinding,
 )
 from .removed_uids import ChangedClassUidFinding, NoChangedClassUidsRule
-from .validator import CompatibilityValidator
+from .validator import CompatibilityValidator, CompatibilityContext
 
 __all__ = [
     "ChangedClassUidFinding",
     "ChangedTypeFinding",
+    "CompatibilityContext",
     "CompatibilityValidator",
     "IncreasedRequirementFinding",
     "NoChangedClassUidsRule",

--- a/src/ocsf/validate/compatibility/__init__.py
+++ b/src/ocsf/validate/compatibility/__init__.py
@@ -1,5 +1,5 @@
-from .context import CompatibilityContext
 from .changed_type import ChangedTypeFinding, NoChangedTypesRule
+from .context import CompatibilityContext
 from .increased_requirement import IncreasedRequirementFinding, NoIncreasedRequirementsRule
 from .removed_records import (
     NoRemovedRecordsRule,

--- a/src/ocsf/validate/compatibility/__main__.py
+++ b/src/ocsf/validate/compatibility/__main__.py
@@ -77,7 +77,7 @@ from ocsf.validate.framework import (
     validate_severities,
 )
 
-from .validator import CompatibilityValidator, CompatibilityContext
+from .validator import CompatibilityContext, CompatibilityValidator
 
 # Various modules use logging. Configure as you see fit.
 # import logging

--- a/src/ocsf/validate/compatibility/__main__.py
+++ b/src/ocsf/validate/compatibility/__main__.py
@@ -77,7 +77,7 @@ from ocsf.validate.framework import (
     validate_severities,
 )
 
-from .validator import CompatibilityValidator
+from .validator import CompatibilityValidator, CompatibilityContext
 
 # Various modules use logging. Configure as you see fit.
 # import logging
@@ -208,7 +208,12 @@ def main():
         exit(1)
 
     # Configure a validator and run it
-    validator = CompatibilityValidator(cast(ChangedSchema, compare(before, after)), severities)
+    context = CompatibilityContext(
+        change=cast(ChangedSchema, compare(before, after)),
+        before=before,
+        after=after,
+    )
+    validator = CompatibilityValidator(context, severities)
     results = validator.validate()
 
     print()

--- a/src/ocsf/validate/compatibility/added_required_attrs.py
+++ b/src/ocsf/validate/compatibility/added_required_attrs.py
@@ -7,7 +7,8 @@ from ocsf.schema import OcsfElementType
 from ocsf.validate.framework import Finding, Rule, RuleMetadata
 from ocsf.validate.framework.validator import Severity
 
-from .validator import CompatibilityContext
+from .context import CompatibilityContext
+
 
 @dataclass
 class AddedRequiredAttrFinding(Finding):
@@ -45,14 +46,18 @@ class NoAddedRequiredAttrsRule(Rule[CompatibilityContext]):
             if isinstance(event, ChangedEvent):
                 for attr_name, attr in event.attributes.items():
                     if isinstance(attr, Addition):
-                        if attr.after.requirement == "required" and not attr_in_added_profile(attr_name, context.change):
+                        if attr.after.requirement == "required" and not attr_in_added_profile(
+                            attr_name, context.change
+                        ):
                             findings.append(AddedRequiredAttrFinding(OcsfElementType.EVENT, (name, attr_name)))
 
         for name, obj in context.change.objects.items():
             if isinstance(obj, ChangedObject):
                 for attr_name, attr in obj.attributes.items():
                     if isinstance(attr, Addition):
-                        if attr.after.requirement == "required" and not attr_in_added_profile(attr_name, context.change):
+                        if attr.after.requirement == "required" and not attr_in_added_profile(
+                            attr_name, context.change
+                        ):
                             findings.append(AddedRequiredAttrFinding(OcsfElementType.OBJECT, (name, attr_name)))
 
         # If there are no profiles, downgrade all findings to warnings because we can't be sure they

--- a/src/ocsf/validate/compatibility/changed_type.py
+++ b/src/ocsf/validate/compatibility/changed_type.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, Difference
 from ocsf.schema import OcsfAttr, OcsfElementType
-from ocsf.validate.framework import Finding, Rule, RuleMetadata
+from ocsf.validate.framework import Finding, Rule, RuleMetadata, Severity
 
 from .context import CompatibilityContext
 
@@ -70,7 +70,11 @@ class NoChangedTypesRule(Rule[CompatibilityContext]):
                     and attr.type.before in context.before.types
                     and context.before.types[attr.type.before].type == context.after.types[attr.type.after].type
                 ):
-                    return None
+                    found = ChangedTypeFinding(
+                        OcsfElementType.EVENT, name, attr_name, attr.type.before, attr.type.after
+                    )
+                    found.set_severity(Severity.WARNING)
+                    return found
 
                 return ChangedTypeFinding(OcsfElementType.EVENT, name, attr_name, attr.type.before, attr.type.after)
 

--- a/src/ocsf/validate/compatibility/changed_type.py
+++ b/src/ocsf/validate/compatibility/changed_type.py
@@ -43,15 +43,28 @@ class NoChangedTypesRule(Rule[CompatibilityContext]):
                 if attr.type.before == "integer_t" and attr.type.after == "long_t":
                     return None
 
-                # `string_t` -> `file_path_t`
                 # PR#1326 reintroduced `file_path_t` and reassigned several
                 # `string_t` attributes to `file_path_t`. This is technically
                 # type narrowing and not backwards compatible, but it was
-                # decided to allow this change on the OCSF Tuesday call. In the
-                # future, we may want to limit this change to OCSF 1.4 -> 1.5.
-                # if attr.type.before == "string_t" and attr.type.after == "file_path_t":
-                #    return None
+                # decided to allow this change on the OCSF Tuesday call. In
+                # addition, it was decided that type changes that don't change
+                # the underlying primitive type should be allowed.
 
+                # string_t => file_path_t
+                if (
+                    attr.type.after in context.after.types
+                    and context.after.types[attr.type.after].type == attr.type.before
+                ):
+                    return None
+
+                # file_path_t => string_t
+                if (
+                    attr.type.before in context.before.types
+                    and context.before.types[attr.type.before].type == attr.type.after
+                ):
+                    return None
+
+                # file_path_t => hostname_t
                 if (
                     attr.type.after in context.after.types
                     and attr.type.before in context.before.types

--- a/src/ocsf/validate/compatibility/context.py
+++ b/src/ocsf/validate/compatibility/context.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from ocsf.schema import OcsfSchema
+from ocsf.compare import ChangedSchema
+
+
+@dataclass
+class CompatibilityContext:
+    change: ChangedSchema
+    before: OcsfSchema
+    after: OcsfSchema

--- a/src/ocsf/validate/compatibility/context.py
+++ b/src/ocsf/validate/compatibility/context.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
-from ocsf.schema import OcsfSchema
+
 from ocsf.compare import ChangedSchema
+from ocsf.schema import OcsfSchema
 
 
 @dataclass

--- a/src/ocsf/validate/compatibility/increased_requirement.py
+++ b/src/ocsf/validate/compatibility/increased_requirement.py
@@ -2,10 +2,11 @@
 
 from dataclasses import dataclass
 
-from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema
+from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject
 from ocsf.schema import OcsfElementType
 from ocsf.validate.framework import Finding, Rule, RuleMetadata
 
+from .validator import CompatibilityContext
 
 @dataclass
 class IncreasedRequirementFinding(Finding):
@@ -30,13 +31,13 @@ without breaking backwards compatibility."""
 _ALLOWED = ["category_uid", "activity_id", "class_uid"]
 
 
-class NoIncreasedRequirementsRule(Rule[ChangedSchema]):
+class NoIncreasedRequirementsRule(Rule[CompatibilityContext]):
     def metadata(self):
         return RuleMetadata("No increased requirements", description=_RULE_DESCRIPTION)
 
-    def validate(self, context: ChangedSchema) -> list[Finding]:
+    def validate(self, context: CompatibilityContext) -> list[Finding]:
         findings: list[Finding] = []
-        for name, event in context.classes.items():
+        for name, event in context.change.classes.items():
             if isinstance(event, ChangedEvent):
                 for attr_name, attr in event.attributes.items():
                     if isinstance(attr, ChangedAttr):
@@ -54,7 +55,7 @@ class NoIncreasedRequirementsRule(Rule[ChangedSchema]):
                                 )
                             )
 
-        for name, obj in context.objects.items():
+        for name, obj in context.change.objects.items():
             if isinstance(obj, ChangedObject):
                 for attr_name, attr in obj.attributes.items():
                     if isinstance(attr, ChangedAttr):

--- a/src/ocsf/validate/compatibility/increased_requirement.py
+++ b/src/ocsf/validate/compatibility/increased_requirement.py
@@ -6,7 +6,8 @@ from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject
 from ocsf.schema import OcsfElementType
 from ocsf.validate.framework import Finding, Rule, RuleMetadata
 
-from .validator import CompatibilityContext
+from .context import CompatibilityContext
+
 
 @dataclass
 class IncreasedRequirementFinding(Finding):

--- a/src/ocsf/validate/compatibility/removed_records.py
+++ b/src/ocsf/validate/compatibility/removed_records.py
@@ -15,7 +15,8 @@ from ocsf.compare import Addition, ChangedAttr, ChangedEvent, ChangedObject, Rem
 from ocsf.schema import OcsfElementType
 from ocsf.validate.framework import Finding, Rule, RuleMetadata
 
-from .validator import CompatibilityContext
+from .context import CompatibilityContext
+
 
 def _path(
     root: Literal[OcsfElementType.OBJECT] | Literal[OcsfElementType.EVENT],

--- a/src/ocsf/validate/compatibility/removed_uids.py
+++ b/src/ocsf/validate/compatibility/removed_uids.py
@@ -2,9 +2,10 @@
 
 from dataclasses import dataclass
 
-from ocsf.compare import Addition, ChangedAttr, ChangedEvent, ChangedSchema, NoChange, Removal
+from ocsf.compare import Addition, ChangedAttr, ChangedEvent, NoChange, Removal
 from ocsf.validate.framework import Finding, Rule, RuleMetadata
 
+from .validator import CompatibilityContext
 
 @dataclass
 class ChangedClassUidFinding(Finding):
@@ -22,13 +23,13 @@ is because the class was moved to a new category or from an extension to
 core."""
 
 
-class NoChangedClassUidsRule(Rule[ChangedSchema]):
+class NoChangedClassUidsRule(Rule[CompatibilityContext]):
     def metadata(self):
         return RuleMetadata("No changed class UIDs", description=_RULE_DESCRIPTION)
 
-    def validate(self, context: ChangedSchema) -> list[Finding]:
+    def validate(self, context: CompatibilityContext) -> list[Finding]:
         findings: list[Finding] = []
-        for name, event in context.classes.items():
+        for name, event in context.change.classes.items():
             if isinstance(event, ChangedEvent):
                 if "class_uid" in event.attributes and isinstance(event.attributes["class_uid"], ChangedAttr):
                     uid = event.attributes["class_uid"]

--- a/src/ocsf/validate/compatibility/removed_uids.py
+++ b/src/ocsf/validate/compatibility/removed_uids.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from ocsf.compare import Addition, ChangedAttr, ChangedEvent, NoChange, Removal
 from ocsf.validate.framework import Finding, Rule, RuleMetadata
 
-from .validator import CompatibilityContext
+from .context import CompatibilityContext
+
 
 @dataclass
 class ChangedClassUidFinding(Finding):

--- a/src/ocsf/validate/compatibility/validator.py
+++ b/src/ocsf/validate/compatibility/validator.py
@@ -2,9 +2,9 @@
 
 from ocsf.validate.framework import Rule, Validator
 
-from .context import CompatibilityContext
 from .added_required_attrs import NoAddedRequiredAttrsRule
 from .changed_type import NoChangedTypesRule
+from .context import CompatibilityContext
 from .increased_requirement import NoIncreasedRequirementsRule
 from .removed_records import NoRemovedRecordsRule
 from .removed_uids import NoChangedClassUidsRule

--- a/src/ocsf/validate/compatibility/validator.py
+++ b/src/ocsf/validate/compatibility/validator.py
@@ -1,22 +1,15 @@
 """A backwards compatibility validator."""
 
-from dataclasses import dataclass
-
-from ocsf.compare import ChangedSchema
-from ocsf.schema import OcsfSchema
 from ocsf.validate.framework import Rule, Validator
 
+from .context import CompatibilityContext
 from .added_required_attrs import NoAddedRequiredAttrsRule
 from .changed_type import NoChangedTypesRule
 from .increased_requirement import NoIncreasedRequirementsRule
 from .removed_records import NoRemovedRecordsRule
 from .removed_uids import NoChangedClassUidsRule
 
-@dataclass
-class CompatibilityContext:
-    change: ChangedSchema
-    before: OcsfSchema
-    after: OcsfSchema
+
 class CompatibilityValidator(Validator[CompatibilityContext]):
     def rules(self) -> list[Rule[CompatibilityContext]]:
         return [

--- a/src/ocsf/validate/compatibility/validator.py
+++ b/src/ocsf/validate/compatibility/validator.py
@@ -1,6 +1,9 @@
 """A backwards compatibility validator."""
 
+from dataclasses import dataclass
+
 from ocsf.compare import ChangedSchema
+from ocsf.schema import OcsfSchema
 from ocsf.validate.framework import Rule, Validator
 
 from .added_required_attrs import NoAddedRequiredAttrsRule
@@ -9,9 +12,13 @@ from .increased_requirement import NoIncreasedRequirementsRule
 from .removed_records import NoRemovedRecordsRule
 from .removed_uids import NoChangedClassUidsRule
 
-
-class CompatibilityValidator(Validator[ChangedSchema]):
-    def rules(self) -> list[Rule[ChangedSchema]]:
+@dataclass
+class CompatibilityContext:
+    change: ChangedSchema
+    before: OcsfSchema
+    after: OcsfSchema
+class CompatibilityValidator(Validator[CompatibilityContext]):
+    def rules(self) -> list[Rule[CompatibilityContext]]:
         return [
             NoRemovedRecordsRule(),
             NoChangedClassUidsRule(),

--- a/src/ocsf/validate/framework/validator.py
+++ b/src/ocsf/validate/framework/validator.py
@@ -73,6 +73,7 @@ class Finding(ABC):
             return self._default_severity()
 
     def set_severity(self, severity: Severity) -> None:
+        print("blah")
         self._severity = severity
 
     def del_severity(self) -> None:

--- a/tests/ocsf/validate/compatibility/helpers.py
+++ b/tests/ocsf/validate/compatibility/helpers.py
@@ -5,6 +5,7 @@ from ocsf.validate.compatibility import CompatibilityContext
 types = {
     "string_t": OcsfType(caption="String", type="string_t"),
     "file_path_t": OcsfType(caption="File Path", type="string_t"),
+    "hostname_t": OcsfType(caption="Hostname", type="string_t"),
 }
 
 

--- a/tests/ocsf/validate/compatibility/helpers.py
+++ b/tests/ocsf/validate/compatibility/helpers.py
@@ -1,0 +1,16 @@
+from ocsf.compare import ChangedSchema
+from ocsf.schema import OcsfSchema, OcsfType
+from ocsf.validate.compatibility import CompatibilityContext
+
+types = {
+    "string_t": OcsfType(caption="String", type="string_t"),
+    "file_path_t": OcsfType(caption="File Path", type="string_t"),
+}
+
+
+def get_context(s: ChangedSchema):
+    return CompatibilityContext(
+        change=s,
+        before=OcsfSchema("1.0.0", types=types),
+        after=OcsfSchema("1.0.1", types=types),
+    )

--- a/tests/ocsf/validate/compatibility/test_added_required_attrs.py
+++ b/tests/ocsf/validate/compatibility/test_added_required_attrs.py
@@ -2,6 +2,7 @@ from ocsf.compare import Addition, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.schema import OcsfAttr, OcsfProfile
 from ocsf.validate.compatibility.added_required_attrs import AddedRequiredAttrFinding, NoAddedRequiredAttrsRule
 from ocsf.validate.framework import Severity
+from .helpers import get_context
 
 
 def test_added_required_attr_event():
@@ -17,7 +18,7 @@ def test_added_required_attr_event():
     )
 
     rule = NoAddedRequiredAttrsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], AddedRequiredAttrFinding)
     assert findings[0].severity == Severity.WARNING
@@ -36,7 +37,7 @@ def test_added_required_attr_object():
     )
 
     rule = NoAddedRequiredAttrsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], AddedRequiredAttrFinding)
     assert findings[0].severity == Severity.WARNING
@@ -66,7 +67,7 @@ def test_added_required_attr_profile():
     )
 
     rule = NoAddedRequiredAttrsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 0
 
     s.classes["file_activity"] = ChangedEvent(
@@ -74,7 +75,7 @@ def test_added_required_attr_profile():
             "file_name": Addition(OcsfAttr(caption="", type="str_t", requirement="required")),
         }
     )
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], AddedRequiredAttrFinding)
     assert findings[0].severity == Severity.ERROR

--- a/tests/ocsf/validate/compatibility/test_added_required_attrs.py
+++ b/tests/ocsf/validate/compatibility/test_added_required_attrs.py
@@ -2,6 +2,7 @@ from ocsf.compare import Addition, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.schema import OcsfAttr, OcsfProfile
 from ocsf.validate.compatibility.added_required_attrs import AddedRequiredAttrFinding, NoAddedRequiredAttrsRule
 from ocsf.validate.framework import Severity
+
 from .helpers import get_context
 
 

--- a/tests/ocsf/validate/compatibility/test_changed_type.py
+++ b/tests/ocsf/validate/compatibility/test_changed_type.py
@@ -9,7 +9,7 @@ def test_changed_type_event():
         classes={
             "process_activity": ChangedEvent(
                 attributes={
-                    "process_name": ChangedAttr(type=Change("str_t", "process_name_t")),
+                    "process_name": ChangedAttr(type=Change("string_t", "long_t")),
                 }
             ),
         }
@@ -27,7 +27,7 @@ def test_changed_type_object():
         objects={
             "process_activity": ChangedObject(
                 attributes={
-                    "process_name": ChangedAttr(type=Change("str_t", "process_name_t")),
+                    "process_name": ChangedAttr(type=Change("string_t", "long_t")),
                 }
             ),
         }

--- a/tests/ocsf/validate/compatibility/test_changed_type.py
+++ b/tests/ocsf/validate/compatibility/test_changed_type.py
@@ -1,5 +1,6 @@
 from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.validate.compatibility import ChangedTypeFinding, NoChangedTypesRule
+from ocsf.validate.framework import Severity
 
 from .helpers import get_context
 
@@ -84,3 +85,28 @@ def test_str_to_filepath():
     rule = NoChangedTypesRule()
     findings = rule.validate(get_context(s))
     assert len(findings) == 0
+
+
+def test_hostname_to_filepath():
+    """Test that changing from hostname_t to file_path_t is allowed but generates a warning."""
+    s = ChangedSchema(
+        objects={
+            "process_activity": ChangedObject(
+                attributes={
+                    "process_name": ChangedAttr(type=Change("hostname_t", "file_path_t")),
+                }
+            ),
+        },
+        classes={
+            "process_activity": ChangedEvent(
+                attributes={
+                    "process_name": ChangedAttr(type=Change("hostname_t", "file_path_t")),
+                }
+            ),
+        },
+    )
+    rule = NoChangedTypesRule()
+    findings = rule.validate(get_context(s))
+    assert len(findings) == 2
+    assert findings[0].severity == Severity.WARNING
+    assert findings[1].severity == Severity.WARNING

--- a/tests/ocsf/validate/compatibility/test_changed_type.py
+++ b/tests/ocsf/validate/compatibility/test_changed_type.py
@@ -1,5 +1,6 @@
 from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.validate.compatibility import ChangedTypeFinding, NoChangedTypesRule
+
 from .helpers import get_context
 
 

--- a/tests/ocsf/validate/compatibility/test_changed_type.py
+++ b/tests/ocsf/validate/compatibility/test_changed_type.py
@@ -1,5 +1,6 @@
 from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.validate.compatibility import ChangedTypeFinding, NoChangedTypesRule
+from .helpers import get_context
 
 
 def test_changed_type_event():
@@ -15,7 +16,7 @@ def test_changed_type_event():
     )
 
     rule = NoChangedTypesRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], ChangedTypeFinding)
 
@@ -33,7 +34,7 @@ def test_changed_type_object():
     )
 
     rule = NoChangedTypesRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], ChangedTypeFinding)
 
@@ -57,7 +58,7 @@ def test_int_to_long():
         },
     )
     rule = NoChangedTypesRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 0
 
 
@@ -80,5 +81,5 @@ def test_str_to_filepath():
         },
     )
     rule = NoChangedTypesRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 0

--- a/tests/ocsf/validate/compatibility/test_increased_requirement.py
+++ b/tests/ocsf/validate/compatibility/test_increased_requirement.py
@@ -1,5 +1,6 @@
 from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.validate.compatibility import IncreasedRequirementFinding, NoIncreasedRequirementsRule
+
 from .helpers import get_context
 
 

--- a/tests/ocsf/validate/compatibility/test_increased_requirement.py
+++ b/tests/ocsf/validate/compatibility/test_increased_requirement.py
@@ -1,5 +1,6 @@
 from ocsf.compare import Change, ChangedAttr, ChangedEvent, ChangedObject, ChangedSchema
 from ocsf.validate.compatibility import IncreasedRequirementFinding, NoIncreasedRequirementsRule
+from .helpers import get_context
 
 
 def test_increased_requirement_event():
@@ -15,7 +16,7 @@ def test_increased_requirement_event():
     )
 
     rule = NoIncreasedRequirementsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], IncreasedRequirementFinding)
 
@@ -33,7 +34,7 @@ def test_increased_requirement_object():
     )
 
     rule = NoIncreasedRequirementsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], IncreasedRequirementFinding)
 
@@ -51,5 +52,5 @@ def test_increased_requirement_event_bugfix():
     )
 
     rule = NoIncreasedRequirementsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 0

--- a/tests/ocsf/validate/compatibility/test_removed_records.py
+++ b/tests/ocsf/validate/compatibility/test_removed_records.py
@@ -11,6 +11,7 @@ from ocsf.validate.compatibility.removed_records import (
     RenamedEventFinding,
     RenamedObjectFinding,
 )
+
 from .helpers import get_context
 
 

--- a/tests/ocsf/validate/compatibility/test_removed_records.py
+++ b/tests/ocsf/validate/compatibility/test_removed_records.py
@@ -11,6 +11,7 @@ from ocsf.validate.compatibility.removed_records import (
     RenamedEventFinding,
     RenamedObjectFinding,
 )
+from .helpers import get_context
 
 
 def test_removed_event():
@@ -19,7 +20,7 @@ def test_removed_event():
     s.classes["email_delivery_activity"] = Removal(OcsfEvent("email_delivery_activity", "Email Delivery Activity"))
 
     rule = NoRemovedRecordsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], RemovedEventFinding)
 
@@ -30,7 +31,7 @@ def test_removed_object():
     s.objects["kill_chain"] = Removal(OcsfObject("kill_chain", "Kill Chain"))
 
     rule = NoRemovedRecordsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], RemovedObjectFinding)
 
@@ -46,7 +47,7 @@ def test_removed_attr():
     )
 
     rule = NoRemovedRecordsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 2
     assert isinstance(findings[0], RemovedAttrFinding)
     assert isinstance(findings[1], RemovedAttrFinding)
@@ -63,7 +64,7 @@ def test_removed_enum_member():
     )
 
     rule = NoRemovedRecordsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 2
     assert isinstance(findings[0], RemovedEnumMemberFinding)
     assert isinstance(findings[1], RemovedEnumMemberFinding)
@@ -78,7 +79,7 @@ def test_renamed_event_caption():
     s.classes["email_delivery"] = Addition(OcsfEvent(name="email_delivery", caption="Email Delivery Activity"))
 
     rule = NoRemovedRecordsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], RenamedEventFinding)
 
@@ -94,7 +95,7 @@ def test_renamed_event_uid():
     s.classes["email_delivery"] = Addition(OcsfEvent(name="email_delivery", caption="Email Activity", attributes=attrs))
 
     rule = NoRemovedRecordsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], RenamedEventFinding)
 
@@ -106,7 +107,7 @@ def test_renamed_object():
     s.objects["kill_chain_phases"] = Addition(OcsfObject(name="kill_chain_phases", caption="Kill Chain"))
 
     rule = NoRemovedRecordsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], RenamedObjectFinding)
 
@@ -122,7 +123,7 @@ def test_renamed_attr():
     )
 
     rule = NoRemovedRecordsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], RenamedAttrFinding)
 
@@ -142,6 +143,6 @@ def test_renamed_enum_member():
     )
 
     rule = NoRemovedRecordsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], RenamedEnumMemberFinding)

--- a/tests/ocsf/validate/compatibility/test_removed_uids.py
+++ b/tests/ocsf/validate/compatibility/test_removed_uids.py
@@ -1,6 +1,7 @@
 from ocsf.compare import Addition, ChangedAttr, ChangedEvent, ChangedSchema, Removal
 from ocsf.schema import OcsfEnumMember
 from ocsf.validate.compatibility import ChangedClassUidFinding, NoChangedClassUidsRule
+
 from .helpers import get_context
 
 

--- a/tests/ocsf/validate/compatibility/test_removed_uids.py
+++ b/tests/ocsf/validate/compatibility/test_removed_uids.py
@@ -1,6 +1,7 @@
 from ocsf.compare import Addition, ChangedAttr, ChangedEvent, ChangedSchema, Removal
 from ocsf.schema import OcsfEnumMember
 from ocsf.validate.compatibility import ChangedClassUidFinding, NoChangedClassUidsRule
+from .helpers import get_context
 
 
 def test_changed_class_uid():
@@ -21,7 +22,7 @@ def test_changed_class_uid():
     )
 
     rule = NoChangedClassUidsRule()
-    findings = rule.validate(s)
+    findings = rule.validate(get_context(s))
     assert len(findings) == 1
     assert isinstance(findings[0], ChangedClassUidFinding)
     assert findings[0].event == "process_activity"


### PR DESCRIPTION
This PR improves on an earlier enhancement to allow attribute types to change from `string_t` to `file_path_t`.

After this PR, attribute types may change provided the before and after type have the same base primitive type.

Examples:
1. `string_t` => `file_path_t`: allowed
2. `file_path_t` => `string_t`: allowed
3. `host_name_t` => `file_path_t`: allowed, but with a warning
4. `integer_t` => `string_t`: disallowed
5. `integer_t` => `ip_t`: disallowed
6. `integer_t` => `network_endpoint`: disallowed

