### PR TITLE
Fix OcsfApiClient and schema handling for version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ the OCSF server does (with very few exceptions). It is meant to provide:
 
 The `ocsf.api` package exports an `OcsfApiClient`, which is a lightweight HTTP
 client that can retrieve a version of the schema over HTTP and cache it on the
-local filesystem. It uses thes `export/schema`, `api/versions`, `api/profiles`,
-and `api/extensions` endpoints of the OCSF server.
+local filesystem. It uses the legacy `export/schema` endpoint for schema
+versions through `1.7.0`, the `export/v2/schema` endpoint for `1.8.0` and
+newer, plus the `api/versions`, `api/profiles`, and `api/extensions` endpoints
+of the OCSF server. The client normalizes the newer export payload into the
+existing Python schema model before deserializing it.
 
 ### ocsf.compare: The Compare Package
 

--- a/src/ocsf/api/client.py
+++ b/src/ocsf/api/client.py
@@ -20,6 +20,7 @@ from copy import copy
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Optional, cast
+from urllib.error import HTTPError
 from urllib.parse import urljoin
 from urllib.request import urlopen
 
@@ -54,6 +55,9 @@ def _is_semver(version: str) -> bool:
 def _semver_sort_key(version: Version) -> int:
     """Return a sort key for a semantic version."""
     return version.major * 1000 + version.minor * 10 + version.patch
+
+
+_V2_SCHEMA_EXPORT_MIN_VERSION = Version.parse("1.8.0")
 
 
 # Models representing the response from the OCSF server's /api/versions endpoint.
@@ -131,13 +135,31 @@ class OcsfApiClient:
         else:
             return self._base_url
 
+    def _schema_export_path(self, version: str) -> str:
+        """Return the schema export path for a resolved version."""
+        if Version.parse(version) >= _V2_SCHEMA_EXPORT_MIN_VERSION:
+            return "export/v2/schema"
+
+        return "export/schema"
+
     def _fetch_schema(self, version: Optional[str] = None) -> OcsfSchema:
         """Fetch a schema from the server."""
-        url = urljoin(self._versioned_url(version), "export/schema")
+        version = self.get_default_version() if version is None else version
+        url = urljoin(self._versioned_url(version), self._schema_export_path(version))
 
         LOG.debug(f"Fetching schema from {url} (version {version})")
-        json_str = urlopen(url).read()
-        return from_json(json_str, self._schema_options)
+        try:
+            json_str = urlopen(url).read()
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise ValueError(f"Failed to fetch schema {version} from {url}: {exc.code} {exc.reason}: {body}") from exc
+
+        schema = from_json(json_str, self._schema_options)
+        if not self._fetch_extensions and schema.extensions is not None:
+            if Version.parse(schema.version) >= _V2_SCHEMA_EXPORT_MIN_VERSION:
+                schema.extensions = None
+
+        return schema
 
     def _fetch_versions(self) -> SchemaVersions:
         """Fetch the available versions from the server."""

--- a/src/ocsf/compare/model.py
+++ b/src/ocsf/compare/model.py
@@ -142,6 +142,8 @@ class ChangedAttr(ChangedModel[OcsfAttr]):
     group: Difference[Optional[str]] = field(default_factory=NoChange)
     observable: Difference[Optional[int]] = field(default_factory=NoChange)
     sibling: Difference[Optional[str]] = field(default_factory=NoChange)
+    object_type: Difference[Optional[str]] = field(default_factory=NoChange)
+    object_name: Difference[Optional[str]] = field(default_factory=NoChange)
     type_name: Difference[Optional[str]] = field(default_factory=NoChange)
     profile: Difference[Optional[str | list[str]]] = field(default_factory=NoChange)
     deprecated: Difference[Optional[OcsfDeprecationInfo]] = field(default_factory=NoChange)

--- a/src/ocsf/compare/model.py
+++ b/src/ocsf/compare/model.py
@@ -142,6 +142,7 @@ class ChangedAttr(ChangedModel[OcsfAttr]):
     group: Difference[Optional[str]] = field(default_factory=NoChange)
     observable: Difference[Optional[int]] = field(default_factory=NoChange)
     sibling: Difference[Optional[str]] = field(default_factory=NoChange)
+    type_name: Difference[Optional[str]] = field(default_factory=NoChange)
     profile: Difference[Optional[str | list[str]]] = field(default_factory=NoChange)
     deprecated: Difference[Optional[OcsfDeprecationInfo]] = field(default_factory=NoChange)
 

--- a/src/ocsf/schema/json.py
+++ b/src/ocsf/schema/json.py
@@ -28,6 +28,52 @@ _NAME_TRANSFORMS = {
 }
 
 
+def _unwrap_attributes(data: Any) -> dict[str, Any] | None:
+    """If the given data is a dictionary with an "attributes" key whose value is also a dictionary, 
+    return the value of the "attributes" key. Otherwise, return None."""
+    if not isinstance(data, dict):
+        return None
+
+    entry = cast(dict[str, Any], data)
+    attributes = entry.get("attributes")
+    if not isinstance(attributes, dict):
+        return None
+
+    return cast(dict[str, Any], attributes)
+
+
+def _with_name(name: str, data: Any) -> dict[str, Any]:
+    """Add a name property to a dictionary if it is not already present."""
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid schema entry for {name}")
+
+    entry = dict(cast(dict[str, Any], data))
+    entry.setdefault("name", name)
+    return entry
+
+
+def normalize_schema_dict(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize server payload differences before deserializing a schema."""
+    # If a dictionary is present but the top-level "types" key is missing, promote the dictionary to the types key.
+    dictionary = _unwrap_attributes(data.get("dictionary"))
+    if dictionary is not None and "types" not in data:
+        data["types"] = dictionary
+
+    # If a categories dictionary is present, promote it to the top level and add names to each category entry.
+    categories = _unwrap_attributes(data.get("categories"))
+    if categories is not None:
+        data["categories"] = {name: _with_name(name, value) for name, value in categories.items()}
+
+    # If profiles are present but the top-level "profiles" key is missing, set profiles to null to avoid deserialization errors.
+    profiles = data.get("profiles")
+    if dictionary is not None and isinstance(profiles, dict):
+        profile_map = cast(dict[str, Any], profiles)
+        if all(isinstance(profile, dict) and "attributes" not in profile for profile in profile_map.values()):
+            data["profiles"] = None
+
+    return data
+
+
 @dataclass
 class SchemaOptions:
     """Options for hydrating OCSF schema properties."""
@@ -91,7 +137,9 @@ def resolve_object_types(things: dict[str, WithAttributes] | OcsfSchema | WithAt
 def from_dict(data: dict[str, Any], options: SchemaOptions | None = None) -> OcsfSchema:
     """Parse an OCSF schema from a dictionary."""
     _options = SchemaOptions() if options is None else options
-    schema = dacite.from_dict(OcsfSchema, keys_to_names(data))
+    normalized_data = normalize_schema_dict(data)
+
+    schema = dacite.from_dict(OcsfSchema, keys_to_names(normalized_data))
 
     if _options.resolve_object_types:
         resolve_object_types(schema)

--- a/src/ocsf/schema/json.py
+++ b/src/ocsf/schema/json.py
@@ -54,10 +54,15 @@ def _with_name(name: str, data: Any) -> dict[str, Any]:
 
 def normalize_schema_dict(data: dict[str, Any]) -> dict[str, Any]:
     """Normalize server payload differences before deserializing a schema."""
-    # If a dictionary is present but the top-level "types" key is missing, promote the dictionary to the types key.
-    dictionary = _unwrap_attributes(data.get("dictionary"))
-    if dictionary is not None and "types" not in data:
-        data["types"] = dictionary
+    # For v2 payloads, the data-type registry lives under dictionary.types.attributes.
+    dictionary_entry = data.get("dictionary")
+    dictionary = _unwrap_attributes(dictionary_entry)
+    dictionary_types = None
+    if isinstance(dictionary_entry, dict):
+        dictionary_types = _unwrap_attributes(cast(dict[str, Any], dictionary_entry).get("types"))
+
+    if dictionary_types is not None and "types" not in data:
+        data["types"] = dictionary_types
 
     # If a categories dictionary is present, promote it to the top level and add names to each category entry.
     categories = _unwrap_attributes(data.get("categories"))

--- a/tests/ocsf/api/test_client.py
+++ b/tests/ocsf/api/test_client.py
@@ -30,10 +30,41 @@ def v2_schema_payload(version: str) -> bytes:
             "classes": {},
             "objects": {},
             "dictionary": {
-                "attributes": {},
+                "attributes": {
+                    "product": {
+                        "caption": "Product",
+                        "description": "The product that reported the event.",
+                        "type": "object_t",
+                        "object_type": "product",
+                        "object_name": "Product",
+                    },
+                    "raw_header": {
+                        "caption": "Raw Header",
+                        "description": "The email authentication header.",
+                        "type": "string_t",
+                        "type_name": "String",
+                    },
+                },
                 "name": "dictionary",
                 "description": "Dictionary",
-                "types": {},
+                "types": {
+                    "attributes": {
+                        "email_t": {
+                            "caption": "Email Address",
+                            "description": "Email address.",
+                            "type": "string_t",
+                            "type_name": "String",
+                            "observable": 5,
+                        },
+                        "uuid_t": {
+                            "caption": "UUID",
+                            "description": "Universal unique identifier.",
+                            "regex": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                            "type": "string_t",
+                            "type_name": "String",
+                        },
+                    }
+                },
                 "caption": "Dictionary",
             },
             "extensions": {
@@ -224,3 +255,19 @@ def test_fetch_schema_omits_embedded_v2_extensions_when_disabled(monkeypatch: py
     schema = OcsfApiClient(fetch_profiles=False, fetch_extensions=False, fetch_categories=False)._fetch_schema("1.8.0")
 
     assert schema.extensions is None
+
+
+def test_fetch_schema_uses_v2_data_types_registry(monkeypatch: pytest.MonkeyPatch):
+    def fake_urlopen(url: str) -> Response:
+        return Response(v2_schema_payload("1.8.0"))
+
+    monkeypatch.setattr(client_module, "urlopen", fake_urlopen)
+
+    schema = OcsfApiClient(fetch_profiles=False, fetch_extensions=False, fetch_categories=False)._fetch_schema("1.8.0")
+
+    assert schema.types["email_t"].type == "string_t"
+    assert schema.types["email_t"].type_name == "String"
+    assert schema.types["uuid_t"].type == "string_t"
+    assert schema.types["uuid_t"].type_name == "String"
+    assert "product" not in schema.types
+    assert "raw_header" not in schema.types

--- a/tests/ocsf/api/test_client.py
+++ b/tests/ocsf/api/test_client.py
@@ -1,8 +1,50 @@
+import json
+from email.message import Message
+from io import BytesIO
+from urllib.error import HTTPError
+
 import pytest
 from semver import Version
 
+import ocsf.api.client as client_module
 from ocsf.api import OcsfApiClient, SchemaVersion, SchemaVersions
 from ocsf.schema.model import OcsfExtension, OcsfProfile, OcsfSchema
+
+
+class Response:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+def schema_payload(version: str) -> bytes:
+    return json.dumps({"version": version, "classes": {}, "objects": {}, "types": {}}).encode()
+
+
+def v2_schema_payload(version: str) -> bytes:
+    return json.dumps(
+        {
+            "version": version,
+            "classes": {},
+            "objects": {},
+            "dictionary": {
+                "attributes": {},
+                "name": "dictionary",
+                "description": "Dictionary",
+                "types": {},
+                "caption": "Dictionary",
+            },
+            "extensions": {
+                "linux": {
+                    "name": "linux",
+                    "uid": 1,
+                    "caption": "Linux",
+                }
+            },
+        }
+    ).encode()
 
 
 def setup() -> OcsfApiClient:
@@ -66,6 +108,20 @@ def test_get_schema_version():
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize("version", ["1.7.0", "1.8.0"])
+def test_get_schema_version_boundary(version: str):
+    """Test fetching schema versions on both sides of the export boundary."""
+    s = setup().get_schema(version)
+
+    assert isinstance(s, OcsfSchema)
+    assert s.version == version
+    assert len(s.classes) > 0
+    assert len(s.objects) > 0
+    assert s.profiles is None
+    assert s.extensions is None
+
+
+@pytest.mark.integration
 def test_get_profiles():
     """Test fetching profiles from the OCSF server."""
     profiles = setup().get_profiles("1.2.0")
@@ -101,3 +157,70 @@ def test_latest_version():
 
     assert versions.latest().version == "1.3.0-dev"
     assert versions.latest_stable().version == "1.2.0"
+
+
+@pytest.mark.parametrize(
+    ("version", "expected_url"),
+    [
+        ("1.7.0", "https://schema.ocsf.io/1.7.0/export/schema"),
+        ("1.8.0", "https://schema.ocsf.io/1.8.0/export/v2/schema"),
+    ],
+)
+def test_fetch_schema_uses_versioned_export_endpoint(monkeypatch: pytest.MonkeyPatch, version: str, expected_url: str):
+    requested_urls: list[str] = []
+
+    def fake_urlopen(url: str) -> Response:
+        requested_urls.append(url)
+        return Response(schema_payload(version))
+
+    monkeypatch.setattr(client_module, "urlopen", fake_urlopen)
+
+    schema = OcsfApiClient(fetch_profiles=False, fetch_extensions=False, fetch_categories=False)._fetch_schema(version)
+
+    assert schema.version == version
+    assert requested_urls == [expected_url]
+
+
+def test_get_schema_uses_default_version_export_endpoint(monkeypatch: pytest.MonkeyPatch):
+    versions = SchemaVersions(
+        default=SchemaVersion(version="1.8.0"),
+        versions=[SchemaVersion(version="1.7.0"), SchemaVersion(version="1.8.0")],
+    )
+    requested_urls: list[str] = []
+
+    def fake_fetch_versions(self: OcsfApiClient) -> SchemaVersions:
+        return versions
+
+    def fake_urlopen(url: str) -> Response:
+        requested_urls.append(url)
+        return Response(schema_payload("1.8.0"))
+
+    monkeypatch.setattr(OcsfApiClient, "_fetch_versions", fake_fetch_versions)
+    monkeypatch.setattr(client_module, "urlopen", fake_urlopen)
+
+    schema = OcsfApiClient(fetch_profiles=False, fetch_extensions=False, fetch_categories=False).get_schema()
+
+    assert schema.version == "1.8.0"
+    assert requested_urls == ["https://schema.ocsf.io/1.8.0/export/v2/schema"]
+
+
+def test_fetch_schema_includes_http_error_body(monkeypatch: pytest.MonkeyPatch):
+    def fake_urlopen(url: str) -> Response:
+        raise HTTPError(url, 400, "Bad Request", hdrs=Message(), fp=BytesIO(b'{"error":"legacy format failure"}'))
+
+    monkeypatch.setattr(client_module, "urlopen", fake_urlopen)
+
+    client = OcsfApiClient(fetch_profiles=False, fetch_extensions=False, fetch_categories=False)
+    with pytest.raises(ValueError, match="legacy format failure"):
+        client._fetch_schema("1.8.0")
+
+
+def test_fetch_schema_omits_embedded_v2_extensions_when_disabled(monkeypatch: pytest.MonkeyPatch):
+    def fake_urlopen(url: str) -> Response:
+        return Response(v2_schema_payload("1.8.0"))
+
+    monkeypatch.setattr(client_module, "urlopen", fake_urlopen)
+
+    schema = OcsfApiClient(fetch_profiles=False, fetch_extensions=False, fetch_categories=False)._fetch_schema("1.8.0")
+
+    assert schema.extensions is None

--- a/tests/ocsf/compare/test_compare.py
+++ b/tests/ocsf/compare/test_compare.py
@@ -1,4 +1,5 @@
 # pyright: reportPrivateUsage = false
+from dataclasses import asdict
 from typing import Any, Optional
 
 from ocsf.compare import (
@@ -6,12 +7,13 @@ from ocsf.compare import (
     Change,
     ChangedAttr,
     ChangedEnumMember,
+    ChangedType,
     NoChange,
     Removal,
     compare,
     compare_dict,
 )
-from ocsf.schema import OcsfAttr, OcsfEnumMember
+from ocsf.schema import OcsfAttr, OcsfEnumMember, OcsfType
 
 
 def test_compare_primitives():
@@ -56,6 +58,49 @@ def test_compare_optional_property():
 
     assert isinstance(diff, ChangedAttr)
     assert diff.group == Change(after=None, before="test")
+
+
+def test_compare_type_metadata_fields():
+    """Test compare() on OcsfType metadata fields that were recently widened."""
+
+    old_type = OcsfType(caption="Product", type="product", object_type="product", object_name="Product")
+    new_type = OcsfType(caption="Product", type="product", object_type="product", object_name="Platform Product")
+    diff = compare(old_type, new_type)
+
+    assert isinstance(diff, ChangedType)
+    assert "object_type" in asdict(diff)
+    assert "object_name" in asdict(diff)
+    assert diff.object_type == NoChange()
+    assert diff.object_name == Change(before="Product", after="Platform Product")
+
+
+def test_compare_attr_metadata_fields():
+    """Test compare() on OcsfAttr metadata fields that should not be dropped."""
+
+    old_attr = OcsfAttr(
+        caption="Raw Header",
+        description="",
+        requirement="required",
+        type="string_t",
+        type_name="String",
+    )
+    new_attr = OcsfAttr(
+        caption="Raw Header",
+        description="",
+        requirement="required",
+        type="string_t",
+        type_name="Text",
+    )
+    diff = compare(old_attr, new_attr)
+
+    assert isinstance(diff, ChangedAttr)
+    serialized = asdict(diff)
+    assert "object_type" in serialized
+    assert "object_name" in serialized
+    assert "type_name" in serialized
+    assert diff.object_type == NoChange()
+    assert diff.object_name == NoChange()
+    assert diff.type_name == Change(before="String", after="Text")
 
 
 def test_compare_optional_dict_property():

--- a/tests/ocsf/compare/test_compare.py
+++ b/tests/ocsf/compare/test_compare.py
@@ -61,17 +61,17 @@ def test_compare_optional_property():
 
 
 def test_compare_type_metadata_fields():
-    """Test compare() on OcsfType metadata fields that were recently widened."""
+    """Test compare() on OcsfType metadata fields exposed by the current schema model."""
 
-    old_type = OcsfType(caption="Product", type="product", object_type="product", object_name="Product")
-    new_type = OcsfType(caption="Product", type="product", object_type="product", object_name="Platform Product")
+    old_type = OcsfType(caption="UUID", type="string_t", type_name="String")
+    new_type = OcsfType(caption="UUID", type="string_t", type_name="Text")
     diff = compare(old_type, new_type)
 
     assert isinstance(diff, ChangedType)
-    assert "object_type" in asdict(diff)
-    assert "object_name" in asdict(diff)
-    assert diff.object_type == NoChange()
-    assert diff.object_name == Change(before="Product", after="Platform Product")
+    serialized = asdict(diff)
+    assert "type_name" in serialized
+    assert diff.type == NoChange()
+    assert diff.type_name == Change(before="String", after="Text")
 
 
 def test_compare_attr_metadata_fields():

--- a/tests/ocsf/compile/test_compiler.py
+++ b/tests/ocsf/compile/test_compiler.py
@@ -73,3 +73,14 @@ def test_order_live():
 
     # No duplicate ops
     assert len(order) == len(set(order))
+
+
+def test_build_keeps_dictionary_attributes_out_of_types():
+    schema = get_compiler().build()
+
+    assert "string_t" in schema.types
+    assert "uuid_t" in schema.types
+    assert schema.types["uuid_t"].type == "string_t"
+    assert schema.types["uuid_t"].type_name == "String"
+    assert "product" not in schema.types
+    assert "raw_header" not in schema.types

--- a/tests/ocsf/schema/test_parsing.py
+++ b/tests/ocsf/schema/test_parsing.py
@@ -58,11 +58,34 @@ V2_JSON_DATA = """{
                 "type": "object_t",
                 "object_type": "product",
                 "object_name": "Product"
+            },
+            "raw_header": {
+                "caption": "Raw Header",
+                "description": "The email authentication header.",
+                "type": "string_t",
+                "type_name": "String"
             }
         },
         "name": "dictionary",
         "description": "Dictionary",
-        "types": {},
+        "types": {
+            "attributes": {
+                "email_t": {
+                    "caption": "Email Address",
+                    "description": "Email address.",
+                    "type": "string_t",
+                    "type_name": "String",
+                    "observable": 5
+                },
+                "uuid_t": {
+                    "caption": "UUID",
+                    "description": "Universal unique identifier.",
+                    "regex": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                    "type": "string_t",
+                    "type_name": "String"
+                }
+            }
+        },
         "caption": "Dictionary"
     },
     "categories": {
@@ -157,7 +180,14 @@ def test_no_resolve_object_types():
 def test_decode_v2_schema_payload():
     schema = from_json(V2_JSON_DATA)
 
-    assert "product" in schema.types
+    assert "email_t" in schema.types
+    assert schema.types["email_t"].type == "string_t"
+    assert schema.types["email_t"].type_name == "String"
+    assert "uuid_t" in schema.types
+    assert schema.types["uuid_t"].type == "string_t"
+    assert schema.types["uuid_t"].type_name == "String"
+    assert "product" not in schema.types
+    assert "raw_header" not in schema.types
     assert schema.categories is not None
     assert "system" in schema.categories
     assert schema.categories["system"].name == "system"

--- a/tests/ocsf/schema/test_parsing.py
+++ b/tests/ocsf/schema/test_parsing.py
@@ -46,6 +46,55 @@ JSON_DATA = """{
   }
 }"""
 
+V2_JSON_DATA = """{
+    "version": "1.8.0",
+    "classes": {},
+    "objects": {},
+    "dictionary": {
+        "attributes": {
+            "product": {
+                "caption": "Product",
+                "description": "The product that reported the event.",
+                "type": "object_t",
+                "object_type": "product",
+                "object_name": "Product"
+            }
+        },
+        "name": "dictionary",
+        "description": "Dictionary",
+        "types": {},
+        "caption": "Dictionary"
+    },
+    "categories": {
+        "attributes": {
+            "system": {
+                "uid": 1,
+                "caption": "System Activity"
+            }
+        },
+        "name": "categories",
+        "description": "Categories",
+        "caption": "Categories"
+    },
+    "profiles": {
+        "trace": {
+            "meta": "profile",
+            "name": "trace",
+            "description": "Trace profile",
+            "caption": "Trace"
+        }
+    },
+    "extensions": {
+        "linux": {
+            "name": "linux",
+            "uid": 1,
+            "caption": "Linux",
+            "platform_extension?": true
+        }
+    },
+    "compile_version": "2.0.0"
+}"""
+
 
 def test_decode_str():
     """Test decoding a JSON string into an OCSF schema."""
@@ -103,3 +152,15 @@ def test_no_resolve_object_types():
     schema = from_json(json_str, SchemaOptions(resolve_object_types=False))
     assert "event" in schema.classes
     assert schema.classes["event"].attributes["thing"].type == "object_t"
+
+
+def test_decode_v2_schema_payload():
+    schema = from_json(V2_JSON_DATA)
+
+    assert "product" in schema.types
+    assert schema.categories is not None
+    assert "system" in schema.categories
+    assert schema.categories["system"].name == "system"
+    assert schema.profiles is None
+    assert schema.extensions is not None
+    assert "linux" in schema.extensions


### PR DESCRIPTION
Enhance OcsfApiClient to support version 1.8.0 while maintaining compatibility with legacy endpoints up to 1.7.0. Implement improved error handling and schema normalization for better data processing.

This was an attempt to fix the issue raised yesterday in <https://github.com/ocsf/ocsf-lib-py/issues/49>